### PR TITLE
🐛 Use Pods project main build configuration.

### DIFF
--- a/Sources/rugby/Common/XcodeProj/Target/XcodeProj+AddTarget.swift
+++ b/Sources/rugby/Common/XcodeProj/Target/XcodeProj+AddTarget.swift
@@ -11,11 +11,24 @@ extension XcodeProj {
     func addTarget(name: String, dependencies: Set<String>) {
         let podsTargets = pbxproj.main.targets.filter { dependencies.contains($0.name) }
         let target = PBXAggregateTarget(name: name, productName: name)
-        target.buildConfigurationList = podsTargets.first?.buildConfigurationList
+        target.buildConfigurationList = pbxproj.main.buildConfigurationList.copy()
         let dependencies = podsTargets.map { PBXTargetDependency(target: $0) }
         dependencies.forEach { pbxproj.add(object: $0) }
         target.dependencies = dependencies
         pbxproj.main.targets.append(target)
         pbxproj.add(object: target)
+    }
+}
+
+private extension XCConfigurationList {
+    func copy() -> XCConfigurationList {
+        let copyBuildConfigurations = buildConfigurations.map {
+            XCBuildConfiguration(name: $0.name,
+                                 baseConfiguration: $0.baseConfiguration,
+                                 buildSettings: $0.buildSettings)
+        }
+        return XCConfigurationList(buildConfigurations: copyBuildConfigurations,
+                                   defaultConfigurationName: defaultConfigurationName,
+                                   defaultConfigurationIsVisible: defaultConfigurationIsVisible)
     }
 }

--- a/Sources/rugby/main.swift
+++ b/Sources/rugby/main.swift
@@ -7,7 +7,7 @@ struct Rugby: ParsableCommand {
         🏈 Shake up pods project, build and throw away part of it.
         📖 \("https://github.com/swiftyfinch/Rugby".cyan) (⌘ + double click on link)
         """,
-        version: "1.7.0",
+        version: "1.7.0-dev",
         subcommands: [
             Plans.self,
             Cache.self,


### PR DESCRIPTION
Probably, sometimes first build target configuration leads to bugs.
We need to use the main build configuration from the Pods project.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary