### PR TITLE
🚑 Rugby doctor & runs history

### DIFF
--- a/Docs/README.md
+++ b/Docs/README.md
@@ -32,3 +32,20 @@ If you run any command without `--verbose` flag you still can get verbosity outp
 ```bash
 rugby log
 ```
+
+## Doctor
+
+If you encourage any problems, please call `rugby doctor` and follow suggestions.
+
+```bash
+🚑 If you encourage any problems, please follow this checklist:
+1. Firstly, update Rugby to the last version;
+2. Run rugby --ignore-checksums;
+3. Try to investigate build logs yourself;
+4. Run rugby clean && rugby --ignore-checksums;
+5. Check that Pods project builds successfully without Rugby.
+
+Report an issue in GitHub discussions or any convenience support channel.
+Attach last files from .rugby/history folder.
+But be sure that there are no sensitive data.
+```

--- a/Sources/rugby/Commands/Cache/Command/CacheHeader.swift
+++ b/Sources/rugby/Commands/Cache/Command/CacheHeader.swift
@@ -9,7 +9,7 @@ import ArgumentParser
 import Rainbow
 
 struct Cache: ParsableCommand {
-    @Option(name: .shortAndLong, help: "Build architechture. (default: x86_64 for sim)") var arch: String?
+    @Option(name: .shortAndLong, help: "Build architechture. (default: \(ARCH.x86_64) for sim)") var arch: String?
     @Option(name: .shortAndLong, help: "Build sdk: sim or ios.") var sdk: SDK = .sim
     @Flag(name: .shortAndLong, help: "Keep Pods group in project.") var keepSources = false
     @Option(name: .shortAndLong, parsing: .upToNextOption, help: "Exclude pods from cache.") var exclude: [String] = []

--- a/Sources/rugby/Commands/Cache/Command/CacheRun.swift
+++ b/Sources/rugby/Commands/Cache/Command/CacheRun.swift
@@ -10,7 +10,7 @@ import Files
 extension Cache: Command {
     mutating func run(logFile: File) throws -> Metrics? {
         // For simulators use arch x86_64 by default.
-        if sdk == .sim && arch == nil { arch = "x86_64" }
+        if sdk == .sim && arch == nil { arch = ARCH.x86_64 }
 
         let metrics = CacheMetrics(project: String.podsProject.basename())
         let factory = CacheStepsFactory(command: self, metrics: metrics, logFile: logFile)

--- a/Sources/rugby/Commands/Cache/Other/Errors/CacheError.swift
+++ b/Sources/rugby/Commands/Cache/Other/Errors/CacheError.swift
@@ -23,7 +23,7 @@ enum CacheError: Error, LocalizedError {
             output = "Couldn't find Xcode CLT.\n".red
                 + "🚑 Check Xcode Preferences → Locations → Command Line Tools.".yellow
         case .buildFailed:
-            let buildCommand = "cat \(String.buildLog) | xcpretty --color | less -r +G"
+            let buildCommand = "cat \(String.buildLog) | xcpretty"
             output = "Build failed.\n".red
                 + "🚑 Run for more info: ".yellow + buildCommand.white
         }

--- a/Sources/rugby/Commands/Doctor/Doctor.swift
+++ b/Sources/rugby/Commands/Doctor/Doctor.swift
@@ -1,0 +1,30 @@
+//
+//  Doctor.swift
+//  
+//
+//  Created by Vyacheslav Khorkov on 03.06.2021.
+//
+
+import ArgumentParser
+
+struct Doctor: ParsableCommand {
+    static var configuration: CommandConfiguration = .init(
+        abstract: "• Show troubleshooting suggestions."
+    )
+
+    func run() throws {
+        let output = """
+        🚑 If you encourage any problems, please follow this checklist:
+        1. Firstly, update Rugby to the last version;
+        2. Run \("rugby --ignore-checksums".yellow);
+        3. Try to investigate build logs yourself;
+        4. Run \("rugby clean && rugby --ignore-checksums".yellow);
+        5. Check that Pods project builds successfully without Rugby.
+
+        Report an issue in GitHub discussions or any convenience support channel.
+        Attach last files from \(".rugby/history".yellow) folder.
+        But be sure that there are \("no sensitive".red) data.
+        """
+        print(output)
+    }
+}

--- a/Sources/rugby/Commands/Plan/Command/PlanRun.swift
+++ b/Sources/rugby/Commands/Plan/Command/PlanRun.swift
@@ -73,7 +73,6 @@ extension Plans {
     }
 
     private func printEmptyLine(logFile: File) {
-        RugbyPrinter(logFile: logFile, verbose: .verbose)
-            .print("---------------------------------".yellow)
+        RugbyPrinter(logFile: logFile, verbose: .verbose).print(.separator)
     }
 }

--- a/Sources/rugby/Commands/Plan/Command/PlanRun.swift
+++ b/Sources/rugby/Commands/Plan/Command/PlanRun.swift
@@ -9,8 +9,12 @@ import Files
 
 extension Plans {
     func runPlans(_ plans: [PlanParser.Plan]) throws {
+        defer { try? HistoryWriter().save() }
+
         let selectedPlan = try selectPlan(plans)
         let logFile = try Folder.current.createFile(at: .log)
+        EnvironmentCollector().write(to: logFile)
+
         var allMetrics: [String: [Metrics]] = [:]
         let time = try measure {
             try selectedPlan.commands.forEach { command in

--- a/Sources/rugby/Common/Command/Command.swift
+++ b/Sources/rugby/Common/Command/Command.swift
@@ -22,6 +22,8 @@ extension Command {
 
 extension Command where Self: ParsableCommand {
     mutating func wrappedRun() throws {
+        defer { try? HistoryWriter().save() }
+
         var metrics: Metrics?
         let logFile = try Folder.current.createFile(at: .log)
         let time = try measure { metrics = try run(logFile: logFile) }

--- a/Sources/rugby/Common/Command/Command.swift
+++ b/Sources/rugby/Common/Command/Command.swift
@@ -26,6 +26,7 @@ extension Command where Self: ParsableCommand {
 
         var metrics: Metrics?
         let logFile = try Folder.current.createFile(at: .log)
+        EnvironmentCollector().write(to: logFile)
         let time = try measure { metrics = try run(logFile: logFile) }
         output(metrics, time: time, logFile: logFile, extended: !hideMetrics)
         done(logFile: logFile, time: time)

--- a/Sources/rugby/Common/Environment/SDK.swift
+++ b/Sources/rugby/Common/Environment/SDK.swift
@@ -17,3 +17,7 @@ enum SDK: String, Codable, ExpressibleByArgument {
         }
     }
 }
+
+enum ARCH {
+    static let x86_64 = "x86_64" // swiftlint:disable:this identifier_name
+}

--- a/Sources/rugby/Common/Environment/String+Env.swift
+++ b/Sources/rugby/Common/Environment/String+Env.swift
@@ -9,6 +9,7 @@ extension String {
 
     // MARK: - Output
     static let finalMessage = "Let's roll 🏈".green
+    static let separator = "---------------------------------".yellow
 
     // MARK: - Common
 

--- a/Sources/rugby/Common/Environment/String+Env.swift
+++ b/Sources/rugby/Common/Environment/String+Env.swift
@@ -21,6 +21,10 @@ extension String {
     static let podsProject = "Pods/Pods.xcodeproj"
     static let podsTargetSupportFiles = "Pods/Target Support Files"
 
+    // MARK: - History
+
+    static let history = supportFolder + "/history"
+
     // MARK: - Cache command
 
     static let defaultXcodeCLTPath = "/Library/Developer/CommandLineTools"
@@ -28,7 +32,6 @@ extension String {
     static let buildTarget = "RugbyPods"
     static let buildLog = supportFolder + "/build.log"
     static let buildFolder = supportFolder + "/build"
-    static let cachedChecksums = supportFolder + "/Checksums"
     static let cacheFile = supportFolder + "/cache.yml"
     static func cacheFolder(sdk: SDK) -> String {
         "${PODS_ROOT}/../" + supportFolder + "/build/Debug-\(sdk.xcodebuild)"

--- a/Sources/rugby/Common/History/EnvironmentCollector.swift
+++ b/Sources/rugby/Common/History/EnvironmentCollector.swift
@@ -1,0 +1,59 @@
+//
+//  EnvironmentCollector.swift
+//  
+//
+//  Created by Vyacheslav Khorkov on 03.06.2021.
+//
+
+import Files
+import Foundation
+
+struct EnvironmentCollector {
+    func write(to logFile: File) {
+        let printer = FilePrinter(file: logFile)
+        let environment = [
+            "Rugby version: " + Rugby.configuration.version,
+            getXcodeVersion(),
+            getSwiftVersion(),
+            getCPU(),
+            getProject(),
+            getGitBranch()
+        ]
+        environment.forEach { printer.print("* " + $0) }
+        printer.print(.separator)
+    }
+
+    private func getXcodeVersion() -> String {
+        let output = try? shell("xcodebuild -version")
+            .components(separatedBy: .newlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " / ")
+        return output ?? "Xcode: " + .unknown
+    }
+
+    private func getSwiftVersion() -> String {
+        let version = try? shell("swift --version").components(separatedBy: .newlines).first
+        return version ?? "Swift: " + .unknown
+    }
+
+    private func getCPU() -> String {
+        let cpu = (try? shell("sysctl -n machdep.cpu.brand_string")) ?? .unknown
+        return "CPU: " + cpu
+    }
+
+    private func getProject() -> String {
+        let project = Folder.current.subfolders
+            .filter { $0.url.pathExtension == "xcodeproj" || $0.url.pathExtension == "xcworkspace" }
+            .map(\.nameExcludingExtension).first
+        return "Project: " + (project ?? .unknown)
+    }
+
+    private func getGitBranch() -> String {
+        let branch = try? shell("git branch --show-current")
+        return "Git branch: " + (branch ?? .unknown)
+    }
+}
+
+private extension String {
+    static let unknown = "Unknown"
+}

--- a/Sources/rugby/Common/History/EnvironmentCollector.swift
+++ b/Sources/rugby/Common/History/EnvironmentCollector.swift
@@ -13,6 +13,7 @@ struct EnvironmentCollector {
         let printer = FilePrinter(file: logFile)
         let environment = [
             "Rugby version: " + Rugby.configuration.version,
+            "Command: rugby " + CommandLine.arguments.dropFirst().joined(separator: " "),
             getXcodeVersion(),
             getSwiftVersion(),
             getCPU(),

--- a/Sources/rugby/Common/History/HistoryWriter.swift
+++ b/Sources/rugby/Common/History/HistoryWriter.swift
@@ -18,7 +18,7 @@ struct HistoryWriter {
         }
 
         let newRecordFolder = try historyFolder.createSubfolder(at: generateFolderName())
-        let filesForCopy: [String] = [.cacheFile, .log, .buildLog]
+        let filesForCopy: [String] = [.cacheFile, .log, .buildLog, .plans]
         try filesForCopy.forEach {
             let file = try? Folder.current.file(at: $0)
             try file?.copy(to: newRecordFolder)

--- a/Sources/rugby/Common/History/HistoryWriter.swift
+++ b/Sources/rugby/Common/History/HistoryWriter.swift
@@ -1,0 +1,41 @@
+//
+//  HistoryWriter.swift
+//  
+//
+//  Created by Vyacheslav Khorkov on 02.06.2021.
+//
+
+import Files
+import Foundation
+
+struct HistoryWriter {
+    func save() throws {
+        let historyFolder = try Folder.current.createSubfolderIfNeeded(at: .history)
+        let historyCount = historyFolder.subfolders.count()
+        if historyCount >= .maxHistoryCount {
+            let sortedFolders = historyFolder.subfolders.sorted { $0.name < $1.name }
+            try sortedFolders.prefix(historyCount - .maxHistoryCount + 1).forEach { try $0.delete() }
+        }
+
+        let newRecordFolder = try historyFolder.createSubfolder(at: generateFolderName())
+        let filesForCopy: [String] = [.cacheFile, .log, .buildLog]
+        try filesForCopy.forEach {
+            let file = try? Folder.current.file(at: $0)
+            try file?.copy(to: newRecordFolder)
+        }
+    }
+
+    private func generateFolderName() -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = .dateFormat
+        return dateFormatter.string(from: Date())
+    }
+}
+
+private extension Int {
+    static let maxHistoryCount = 10
+}
+
+private extension String {
+    static let dateFormat = "dd.MM.yyyy'T'HH.mm.ss"
+}

--- a/Sources/rugby/main.swift
+++ b/Sources/rugby/main.swift
@@ -14,7 +14,8 @@ struct Rugby: ParsableCommand {
             Focus.self,
             Drop.self,
             Log.self,
-            Clean.self
+            Clean.self,
+            Doctor.self
         ],
         defaultSubcommand: Plans.self
     )


### PR DESCRIPTION
Recently, there are lots of similar help requests. And I decided to add 🏈 Rugby doctor 😀

- [x] Now all logs save in the history folder;
- [x] You can investigate history yourself or call `rugby doctor` for requesting troubleshooting suggestions;
- [x] Otherwise, you can report an issue with attaching the last history records.

Feel free to suggest any additions to 🏈 Rugby doctor checklist.

<img width="700" alt="Screenshot 2021-06-03 at 23 19 49" src="https://user-images.githubusercontent.com/64660122/120706926-5c874300-c4c2-11eb-9892-97b7fa7f207e.png">

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary