### PR TITLE
🐛 Recalculate checksums after build

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,7 @@ Or read more [about Plans](Docs/Plans.md#-generate-example) ✈️
 
 ### `Maybe Roadmap`
 
-- [x] Open source
-- [x] Optimization
-- [ ] CI
-  - [x] Pull requests CI
-  - [x] Move e2e tests to Fastlane
-  - [ ] Unit tests
-  - [ ] Speed up e2e tests
+- [ ] Unit tests
 - [ ] [Improve Cache command](https://github.com/apple/swift-argument-parser/pull/317)
 
 ### `Author`

--- a/Sources/Rugby/Commands/Cache/Command/CacheRun.swift
+++ b/Sources/Rugby/Commands/Cache/Command/CacheRun.swift
@@ -15,7 +15,7 @@ extension Cache: Command {
         let metrics = CacheMetrics(project: String.podsProject.basename())
         let factory = CacheStepsFactory(command: self, metrics: metrics, logFile: logFile)
         let info = try factory.prepare(.buildTarget)
-        try factory.build(.init(scheme: info.scheme, checksums: info.checksums, swift: info.swiftVersion))
+        try factory.build(.init(scheme: info.scheme, buildPods: info.buildPods, swift: info.swiftVersion))
         try factory.integrate(info.targets)
         try factory.cleanup(.init(scheme: info.scheme, targets: info.targets, products: info.products))
         return metrics

--- a/Sources/Rugby/Commands/Cache/Other/Checksums/ChecksumsProvider.swift
+++ b/Sources/Rugby/Commands/Cache/Other/Checksums/ChecksumsProvider.swift
@@ -28,8 +28,6 @@ struct Checksum {
 }
 
 final class ChecksumsProvider {
-    static let shared = ChecksumsProvider()
-
     private let podsProvider = PodsProvider.shared
     private var cachedChecksums: [String: Checksum]?
 

--- a/Sources/Rugby/Commands/Cache/Steps/Prepare/CachePrepareStep.swift
+++ b/Sources/Rugby/Commands/Cache/Steps/Prepare/CachePrepareStep.swift
@@ -11,7 +11,7 @@ struct CachePrepareStep: Step {
     struct Output {
         let scheme: String?
         let targets: Set<String>
-        let checksums: [Checksum]
+        let buildPods: Set<String>
         let products: Set<String>
         let swiftVersion: String?
     }
@@ -47,7 +47,7 @@ extension CachePrepareStep {
         metrics.targetsCount.before = project.pbxproj.main.targets.count
         let factory = CacheSubstepFactory(progress: progress, command: command, metrics: metrics)
         let selectedPods = try factory.selectPods(project)
-        let (buildPods, focusChecksums, swiftVersion) = try factory.findBuildPods(selectedPods)
+        let (buildPods, swiftVersion) = try factory.findBuildPods(selectedPods)
         let (selectedTargets, buildTargets) = try factory.buildTargets((project: project,
                                                                         selectedPods: selectedPods,
                                                                         buildPods: buildPods))
@@ -58,7 +58,7 @@ extension CachePrepareStep {
         done()
         return Output(scheme: buildTargets.isEmpty ? nil : buildTarget,
                       targets: Set(selectedTargets.map(\.name)).union(selectedPods),
-                      checksums: focusChecksums,
+                      buildPods: buildPods,
                       products: Set(selectedTargets.compactMap(\.product?.name)),
                       swiftVersion: swiftVersion)
     }

--- a/Sources/Rugby/Commands/Cache/Steps/Prepare/Substeps/FindBuildPods.swift
+++ b/Sources/Rugby/Commands/Cache/Steps/Prepare/Substeps/FindBuildPods.swift
@@ -16,7 +16,6 @@ extension CacheSubstepFactory {
 
         func run(_ selectedPods: Set<String>) throws -> (
             buildPods: Set<String>,
-            focusChecksums: [Checksum],
             swiftVersion: String?
         ) {
             let focusChecksums = try progress.spinner("Caclulate checksums") {
@@ -36,7 +35,7 @@ extension CacheSubstepFactory {
             } else {
                 buildPods = selectedPods
             }
-            return (buildPods, focusChecksums, swiftVersion)
+            return (buildPods, swiftVersion)
         }
     }
 }

--- a/Sources/rugby/Commands/Cache/Command/CacheRun.swift
+++ b/Sources/rugby/Commands/Cache/Command/CacheRun.swift
@@ -15,7 +15,7 @@ extension Cache: Command {
         let metrics = CacheMetrics(project: String.podsProject.basename())
         let factory = CacheStepsFactory(command: self, metrics: metrics, logFile: logFile)
         let info = try factory.prepare(.buildTarget)
-        try factory.build(.init(scheme: info.scheme, checksums: info.checksums, swift: info.swiftVersion))
+        try factory.build(.init(scheme: info.scheme, buildPods: info.buildPods, swift: info.swiftVersion))
         try factory.integrate(info.targets)
         try factory.cleanup(.init(scheme: info.scheme, targets: info.targets, products: info.products))
         return metrics

--- a/Sources/rugby/Commands/Cache/Other/Checksums/ChecksumsProvider.swift
+++ b/Sources/rugby/Commands/Cache/Other/Checksums/ChecksumsProvider.swift
@@ -28,8 +28,6 @@ struct Checksum {
 }
 
 final class ChecksumsProvider {
-    static let shared = ChecksumsProvider()
-
     private let podsProvider = PodsProvider.shared
     private var cachedChecksums: [String: Checksum]?
 

--- a/Sources/rugby/Commands/Cache/Steps/Prepare/CachePrepareStep.swift
+++ b/Sources/rugby/Commands/Cache/Steps/Prepare/CachePrepareStep.swift
@@ -11,7 +11,7 @@ struct CachePrepareStep: Step {
     struct Output {
         let scheme: String?
         let targets: Set<String>
-        let checksums: [Checksum]
+        let buildPods: Set<String>
         let products: Set<String>
         let swiftVersion: String?
     }
@@ -47,7 +47,7 @@ extension CachePrepareStep {
         metrics.targetsCount.before = project.pbxproj.main.targets.count
         let factory = CacheSubstepFactory(progress: progress, command: command, metrics: metrics)
         let selectedPods = try factory.selectPods(project)
-        let (buildPods, focusChecksums, swiftVersion) = try factory.findBuildPods(selectedPods)
+        let (buildPods, swiftVersion) = try factory.findBuildPods(selectedPods)
         let (selectedTargets, buildTargets) = try factory.buildTargets((project: project,
                                                                         selectedPods: selectedPods,
                                                                         buildPods: buildPods))
@@ -58,7 +58,7 @@ extension CachePrepareStep {
         done()
         return Output(scheme: buildTargets.isEmpty ? nil : buildTarget,
                       targets: Set(selectedTargets.map(\.name)).union(selectedPods),
-                      checksums: focusChecksums,
+                      buildPods: buildPods,
                       products: Set(selectedTargets.compactMap(\.product?.name)),
                       swiftVersion: swiftVersion)
     }

--- a/Sources/rugby/Commands/Cache/Steps/Prepare/Substeps/FindBuildPods.swift
+++ b/Sources/rugby/Commands/Cache/Steps/Prepare/Substeps/FindBuildPods.swift
@@ -16,7 +16,6 @@ extension CacheSubstepFactory {
 
         func run(_ selectedPods: Set<String>) throws -> (
             buildPods: Set<String>,
-            focusChecksums: [Checksum],
             swiftVersion: String?
         ) {
             let focusChecksums = try progress.spinner("Caclulate checksums") {
@@ -36,7 +35,7 @@ extension CacheSubstepFactory {
             } else {
                 buildPods = selectedPods
             }
-            return (buildPods, focusChecksums, swiftVersion)
+            return (buildPods, swiftVersion)
         }
     }
 }


### PR DESCRIPTION
Before this pull request, all pod checksums were calculated at the start of 🏈 Rugby run.
But that's not enough because some pods have scripts that can generate files.
It could make checksums stale right after build.

That request add recalculation build pods checksums after the build process.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary