### PR TITLE
🎨 Beautify build logs

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -11,6 +11,15 @@
         }
       },
       {
+        "package": "Colorizer",
+        "repositoryURL": "https://github.com/getGuaka/Colorizer.git",
+        "state": {
+          "branch": null,
+          "revision": "2ccc99bf1715e73c4139e8d40b6e6b30be975586",
+          "version": "0.2.1"
+        }
+      },
+      {
         "package": "Files",
         "repositoryURL": "https://github.com/JohnSundell/Files",
         "state": {
@@ -62,6 +71,15 @@
           "branch": null,
           "revision": "99680b2efc7c7dbcace1da0b3979d266f02e213c",
           "version": "5.1.0"
+        }
+      },
+      {
+        "package": "xcbeautify",
+        "repositoryURL": "https://github.com/thii/xcbeautify.git",
+        "state": {
+          "branch": null,
+          "revision": "7305183edac003dae3dc56ce35d039df7bccc3b4",
+          "version": null
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,10 @@ let package = Package(
         .package(url: "https://github.com/JohnSundell/Files", from: "4.2.0"),
         .package(name: "XcodeProj", url: "https://github.com/tuist/xcodeproj", from: "7.22.0"),
         .package(url: "https://github.com/kareman/SwiftShell", from: "5.1.0"),
-        .package(url: "https://github.com/jpsim/Yams.git", from: "4.0.6")
+        .package(url: "https://github.com/jpsim/Yams.git", from: "4.0.6"),
+
+        // Need await the new version
+        .package(url: "https://github.com/thii/xcbeautify.git", .revision("7305183edac003dae3dc56ce35d039df7bccc3b4"))
     ],
     targets: [
         .target(name: "Rugby", dependencies: [
@@ -25,6 +28,7 @@ let package = Package(
             "XcodeProj",
             "SwiftShell",
             "Yams",
+            .product(name: "XcbeautifyLib", package: "xcbeautify")
         ])
     ]
 )

--- a/Sources/Rugby/Commands/Cache/Other/Build/LogFormatter.swift
+++ b/Sources/Rugby/Commands/Cache/Other/Build/LogFormatter.swift
@@ -1,0 +1,40 @@
+//
+//  LogFormatter.swift
+//  
+//
+//  Created by Vyacheslav Khorkov on 07.06.2021.
+//
+
+import XcbeautifyLib
+
+final class LogFormatter {
+    private var output: (String) throws -> Void
+    private var buffer: [String] = []
+    private let minBufferSize = 3
+    private let parser = Parser()
+
+    init(output: @escaping (String) throws -> Void) {
+        self.output = output
+    }
+
+    func format(line: String) throws {
+        buffer.append(line)
+        if buffer.count >= minBufferSize {
+            try parse()
+        }
+    }
+
+    func finish() throws {
+        while !buffer.isEmpty {
+            try parse()
+        }
+    }
+
+    private func parse() throws {
+        guard let formatted = parser.parse(line: buffer.removeFirst(), additionalLines: { [weak self] in
+            guard let self = self, !self.buffer.isEmpty else { return nil }
+            return self.buffer.removeFirst()
+        }) else { return }
+        try output(formatted)
+    }
+}

--- a/Sources/Rugby/Commands/Cache/Other/Build/XcodeBuild.swift
+++ b/Sources/Rugby/Commands/Cache/Other/Build/XcodeBuild.swift
@@ -24,9 +24,8 @@ struct XcodeBuild {
         if let arch = arch {
             arguments.append("ARCHS=\(arch)")
         }
-        arguments.append("| tee " + .buildLog)
 
-        try shell(
+        try XcodeBuildRunner(rawLogPath: .rawBuildLog, logPath: .buildLog).run(
             "set -o pipefail && NSUnbufferedIO=YES xcodebuild",
             args: arguments
         )

--- a/Sources/Rugby/Commands/Cache/Other/Build/XcodeBuildRunner.swift
+++ b/Sources/Rugby/Commands/Cache/Other/Build/XcodeBuildRunner.swift
@@ -6,37 +6,28 @@
 //
 
 import Files
-import Foundation
-import SwiftShell
 
-struct XcodeBuildRunner {
+final class XcodeBuildRunner {
     let rawLogPath: String
     let logPath: String
-    private let shellRunner = ShellRunner.shared
+
+    init(rawLogPath: String, logPath: String) {
+        self.rawLogPath = rawLogPath
+        self.logPath = logPath
+    }
 
     func run(_ command: String, args: Any ...) throws {
+        let log = try Folder.current.createFile(at: logPath)
+        let logFormatter = LogFormatter { formattedLine in
+            try log.append(formattedLine + "\n")
+        }
+
         let rawLog = try Folder.current.createFile(at: rawLogPath)
-        let command = try shellRunner.runAsync(command, args: args)
-
-        var error: Error?
-        let group = DispatchGroup()
-        command.stdout.onOutput { handler in
-            for line in handler.lines() {
-                do {
-                    try rawLog.append(line + "\n")
-                } catch let fileError {
-                    error = fileError
-                    command.interrupt()
-                }
-            }
+        let command = try ShellRunner.shared.runAsync(command, args: args)
+        for line in command.stdout.lines() {
+            try rawLog.append(line + "\n")
+            try logFormatter.format(line: line)
         }
-
-        group.enter()
-        command.onCompletion { _ in
-            group.leave()
-        }
-
-        group.wait()
-        if let error = error { throw error }
+        try logFormatter.finish()
     }
 }

--- a/Sources/Rugby/Commands/Cache/Other/Build/XcodeBuildRunner.swift
+++ b/Sources/Rugby/Commands/Cache/Other/Build/XcodeBuildRunner.swift
@@ -1,0 +1,42 @@
+//
+//  XcodeBuildRunner.swift
+//  
+//
+//  Created by Vyacheslav Khorkov on 05.06.2021.
+//
+
+import Files
+import Foundation
+import SwiftShell
+
+struct XcodeBuildRunner {
+    let rawLogPath: String
+    let logPath: String
+    private let shellRunner = ShellRunner.shared
+
+    func run(_ command: String, args: Any ...) throws {
+        let rawLog = try Folder.current.createFile(at: rawLogPath)
+        let command = try shellRunner.runAsync(command, args: args)
+
+        var error: Error?
+        let group = DispatchGroup()
+        command.stdout.onOutput { handler in
+            for line in handler.lines() {
+                do {
+                    try rawLog.append(line + "\n")
+                } catch let fileError {
+                    error = fileError
+                    command.interrupt()
+                }
+            }
+        }
+
+        group.enter()
+        command.onCompletion { _ in
+            group.leave()
+        }
+
+        group.wait()
+        if let error = error { throw error }
+    }
+}

--- a/Sources/Rugby/Commands/Cache/Other/Errors/CacheError.swift
+++ b/Sources/Rugby/Commands/Cache/Other/Errors/CacheError.swift
@@ -23,9 +23,9 @@ enum CacheError: Error, LocalizedError {
             output = "Couldn't find Xcode CLT.\n".red
                 + "🚑 Check Xcode Preferences → Locations → Command Line Tools.".yellow
         case .buildFailed:
-            let buildCommand = "cat \(String.rawBuildLog) | xcpretty"
+            let buildCommand = "cat \(String.buildLog)"
             output = "Build failed.\n".red
-                + "🚑 Run for more info: ".yellow + buildCommand.white
+                + "🚑 Get more info: ".yellow + buildCommand.white
         }
         return output
     }

--- a/Sources/Rugby/Commands/Cache/Other/Errors/CacheError.swift
+++ b/Sources/Rugby/Commands/Cache/Other/Errors/CacheError.swift
@@ -23,7 +23,7 @@ enum CacheError: Error, LocalizedError {
             output = "Couldn't find Xcode CLT.\n".red
                 + "🚑 Check Xcode Preferences → Locations → Command Line Tools.".yellow
         case .buildFailed:
-            let buildCommand = "cat \(String.buildLog) | xcpretty"
+            let buildCommand = "cat \(String.rawBuildLog) | xcpretty"
             output = "Build failed.\n".red
                 + "🚑 Run for more info: ".yellow + buildCommand.white
         }

--- a/Sources/Rugby/Commands/Cache/Steps/CacheCleanupStep.swift
+++ b/Sources/Rugby/Commands/Cache/Steps/CacheCleanupStep.swift
@@ -12,7 +12,7 @@ struct CacheCleanupStep: Step {
     struct Input {
         let scheme: String?
         let targets: Set<String>
-        let products: Set<String>
+        let products: [String]
     }
 
     let verbose: Int
@@ -31,7 +31,7 @@ struct CacheCleanupStep: Step {
     }
 
     func run(_ input: Input) throws {
-        let (targets, products) = (input.targets, input.products)
+        let (targets, products) = (input.targets, Set(input.products))
         var hasChanges = false
 
         let project = try progress.spinner("Read project") {

--- a/Sources/Rugby/Commands/Cache/Steps/Prepare/CachePrepareStep.swift
+++ b/Sources/Rugby/Commands/Cache/Steps/Prepare/CachePrepareStep.swift
@@ -12,7 +12,7 @@ struct CachePrepareStep: Step {
         let scheme: String?
         let targets: Set<String>
         let buildPods: Set<String>
-        let products: Set<String>
+        let products: [String]
         let swiftVersion: String?
     }
 
@@ -59,7 +59,7 @@ extension CachePrepareStep {
         return Output(scheme: buildTargets.isEmpty ? nil : buildTarget,
                       targets: Set(selectedTargets.map(\.name)).union(selectedPods),
                       buildPods: buildPods,
-                      products: Set(selectedTargets.compactMap(\.product?.name)),
+                      products: selectedTargets.compactMap(\.product?.name),
                       swiftVersion: swiftVersion)
     }
 }

--- a/Sources/Rugby/Commands/Clean/Clean.swift
+++ b/Sources/Rugby/Commands/Clean/Clean.swift
@@ -10,8 +10,7 @@ import Files
 
 struct Clean: ParsableCommand {
     static var configuration = CommandConfiguration(
-        abstract: "Remove .rugby cache folder.",
-        shouldDisplay: false
+        abstract: "• Remove cache except \("plans.yml".yellow) and logs."
     )
 
     func run() throws {
@@ -32,17 +31,16 @@ struct CleanStep: Step {
     }
 
     func run(_ input: Void) {
-        try? Folder.current.subfolder(at: .buildFolder).delete()
-        progress.print("Removed \(String.buildFolder)".yellow)
+        if (try? Folder.current.subfolder(at: .buildFolder).delete()) != nil {
+            progress.print("Removed \(String.buildFolder)".yellow)
+        }
 
-        try? Folder.current.file(at: .buildLog).delete()
-        progress.print("Removed \(String.buildLog)".yellow)
-
-        try? Folder.current.file(at: .log).delete()
-        progress.print("Removed \(String.log)".yellow)
-
-        try? Folder.current.file(at: .cacheFile).delete()
-        progress.print("Removed \(String.cacheFile)".yellow)
+        let filesForDelete: [String] = [.cacheFile]
+        filesForDelete.forEach {
+            if (try? Folder.current.file(at: $0).delete()) != nil {
+                progress.print("Removed \($0)".yellow)
+            }
+        }
 
         done()
     }

--- a/Sources/Rugby/Common/Environment/String+Env.swift
+++ b/Sources/Rugby/Common/Environment/String+Env.swift
@@ -31,6 +31,7 @@ extension String {
     static let defaultXcodeCLTPath = "/Library/Developer/CommandLineTools"
 
     static let buildTarget = "RugbyPods"
+    static let rawBuildLog = supportFolder + "/rawBuild.log"
     static let buildLog = supportFolder + "/build.log"
     static let buildFolder = supportFolder + "/build"
     static let cacheFile = supportFolder + "/cache.yml"

--- a/Sources/Rugby/Common/History/HistoryWriter.swift
+++ b/Sources/Rugby/Common/History/HistoryWriter.swift
@@ -18,7 +18,7 @@ struct HistoryWriter {
         }
 
         let newRecordFolder = try historyFolder.createSubfolder(at: generateFolderName())
-        let filesForCopy: [String] = [.cacheFile, .log, .buildLog, .plans]
+        let filesForCopy: [String] = [.cacheFile, .log, .rawBuildLog, .buildLog, .plans]
         try filesForCopy.forEach {
             let file = try? Folder.current.file(at: $0)
             try file?.copy(to: newRecordFolder)

--- a/Sources/Rugby/main.swift
+++ b/Sources/Rugby/main.swift
@@ -14,8 +14,8 @@ struct Rugby: ParsableCommand {
             Focus.self,
             Drop.self,
             Log.self,
-            Clean.self,
-            Doctor.self
+            Doctor.self,
+            Clean.self
         ],
         defaultSubcommand: Plans.self
     )


### PR DESCRIPTION
I used https://github.com/thii/xcbeautify/pull/55 to beautify build logs.
After that pull request, we can use `cat .rugby/.build.log` to see the already formatted output.
Also, I decided to make `rugby clean` command visible again)

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary