### PR TITLE
🚧 Use `--graph` by default

### DIFF
--- a/Docs/Plans.md
+++ b/Docs/Plans.md
@@ -40,7 +40,7 @@ rugby example
   # 🏈 The first Rugby command without arguments like: $ rugby cache
   - command: cache
     # Optional parameters with default values:
-    graph: false
+    graph: true
     arch: null # By default x86_64 if sdk == sim
     sdk: sim
     keepSources: false

--- a/Sources/Rugby/Commands/Cache/Command/CacheHeader.swift
+++ b/Sources/Rugby/Commands/Cache/Command/CacheHeader.swift
@@ -13,14 +13,14 @@ struct Cache: ParsableCommand {
     @Option(name: .shortAndLong, help: "Build sdk: sim or ios.") var sdk: SDK = .sim
     @Flag(name: .shortAndLong, help: "Keep Pods group in project.") var keepSources = false
     @Option(name: .shortAndLong, parsing: .upToNextOption, help: "Exclude pods from cache.") var exclude: [String] = []
-    @Flag(help: "Ignore already cached pods checksums.") var ignoreChecksums = false
     @Option(name: .long,
             parsing: .upToNextOption,
             help: ArgumentHelp("Include local pods.", shouldDisplay: false)) var include: [String] = []
     @Option(name: .long,
             parsing: .upToNextOption,
             help: ArgumentHelp("Keep selected pods.", shouldDisplay: false)) var focus: [String] = []
-    @Flag(help: "Add parents of changed pods to build process.\n") var graph = false
+    @Flag(inversion: .prefixedNo, help: "Build changed pods parents.") var graph = true
+    @Flag(help: "Ignore already cached pods checksums.\n") var ignoreChecksums = false
 
     @Flag(name: .long, inversion: .prefixedNo, help: "Play bell sound on finish.") var bell = true
     @Flag(help: "Hide metrics.") var hideMetrics = false

--- a/Sources/Rugby/Commands/Plan/Parser/DecodableModels/CacheDecodable.swift
+++ b/Sources/Rugby/Commands/Plan/Parser/DecodableModels/CacheDecodable.swift
@@ -28,7 +28,7 @@ extension Cache {
         self.ignoreChecksums = decodable.ignoreChecksums ?? false
         self.include = decodable.include ?? []
         self.focus = decodable.focus ?? []
-        self.graph = decodable.graph ?? false
+        self.graph = decodable.graph ?? true
         self.bell = decodable.bell ?? true
         self.hideMetrics = decodable.hideMetrics ?? false
         self.verbose = decodable.verbose ?? 0

--- a/Sources/Rugby/Commands/Plan/Subcommands/PlansExample.swift
+++ b/Sources/Rugby/Commands/Plan/Subcommands/PlansExample.swift
@@ -60,7 +60,7 @@ struct PlansExample: ParsableCommand {
           # 🏈 The first Rugby command without arguments like: $ rugby cache
           - command: cache
             # Optional parameters with default values:
-            #graph: false
+            #graph: true
             #arch: null # By default x86_64 if sdk == sim
             #sdk: sim
             #keepSources: false


### PR DESCRIPTION
Sometimes after the bump patch version, it breaks the build of dependent pods.
Option `--graph` fix these cases. Now I decided to enable it by default because these cases are hard to investigate.
Also, in that case, you need to use full rebuild with `--ignore-checksums` option.
If you encourage that `rugby` process takes more time you can disable this option by passing `--no-graph`.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary