### PR TITLE
👀 Open local pods options

### DIFF
--- a/Docs/Cache.md
+++ b/Docs/Cache.md
@@ -9,6 +9,8 @@ OPTIONS:
   -s, --sdk <sdk>          Build sdk: sim or ios. (default: sim)
   -k, --keep-sources       Keep Pods group in project.
   -e, --exclude <exclude>  Exclude pods from cache.
+  --include <include>      Include local pods.
+  --focus <focus>          Keep selected local pods and cache others.
   --ignore-checksums       Ignore already cached pods checksums.
   --graph                  Add parents of changed pods to build process.
                             
@@ -68,6 +70,26 @@ rugby --exclude Alamofire SnapKit
 
 ```bash
 rugby --sdk ios
+```
+
+## Build local pods
+
+You can include some local pods to cache:
+
+```bash
+rugby --include MyLocalPods1 MyLocalPods2
+```
+
+If you want to focus on some local pods and cache all others:
+
+```bash
+rugby --focus MyFocusedPod1 MyFocusedPod2
+```
+
+If you want to cache all local pods ([Maybe someday there will be another solution](https://github.com/apple/swift-argument-parser/pull/317)):
+
+```bash
+rugby --focus ""
 ```
 
 ## Ignore checksums

--- a/Docs/Plans.md
+++ b/Docs/Plans.md
@@ -45,6 +45,8 @@ rugby example
     sdk: sim
     keepSources: false
     exclude: []
+    include: []
+    focus: []
     hideMetrics: false
     ignoreChecksums: false
     verbose: false

--- a/Sources/Rugby/Commands/Cache/Command/CacheHeader.swift
+++ b/Sources/Rugby/Commands/Cache/Command/CacheHeader.swift
@@ -14,12 +14,8 @@ struct Cache: ParsableCommand {
     @Option(name: .shortAndLong, help: "Build sdk: sim or ios.") var sdk: SDK = .sim
     @Flag(name: .shortAndLong, help: "Keep Pods group in project.") var keepSources = false
     @Option(name: .shortAndLong, parsing: .upToNextOption, help: "Exclude pods from cache.") var exclude: [String] = []
-    @Option(name: .long,
-            parsing: .upToNextOption,
-            help: ArgumentHelp("Include local pods.", shouldDisplay: false)) var include: [String] = []
-    @Option(name: .long,
-            parsing: .upToNextOption,
-            help: ArgumentHelp("Keep selected pods.", shouldDisplay: false)) var focus: [String] = []
+    @Option(parsing: .upToNextOption, help: "Include local pods.") var include: [String] = []
+    @Option(parsing: .upToNextOption, help: "Keep selected local pods and cache others.") var focus: [String] = []
     @Flag(inversion: .prefixedNo, help: "Build changed pods parents.") var graph = true
     @Flag(help: "Ignore already cached pods checksums.\n") var ignoreChecksums = false
 

--- a/Sources/Rugby/Commands/Plan/Subcommands/PlansExample.swift
+++ b/Sources/Rugby/Commands/Plan/Subcommands/PlansExample.swift
@@ -66,6 +66,8 @@ struct PlansExample: ParsableCommand {
             #sdk: sim
             #keepSources: false
             #exclude: []
+            #include: []
+            #focus: []
             #hideMetrics: false
             #ignoreChecksums: false
             #verbose: false


### PR DESCRIPTION
In this request, I opened include and focus options of Cache command.
These options were added a month ago and finally, look stable enough.

## Build local pods

You can include some local pods to cache:

```bash
rugby --include MyLocalPods1 MyLocalPods2
```

If you want to focus on some local pods and cache all others:

```bash
rugby --focus MyFocusedPod1 MyFocusedPod2
```

If you want to cache all local pods ([Maybe someday there will be another solution](https://github.com/apple/swift-argument-parser/pull/317)):

```bash
rugby --focus ""
```

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary