### PR TITLE
🐛 Use subfolder if pod source is file

### DIFF
--- a/Sources/Rugby/Commands/Cache/Other/Checksums/CombinedChecksum.swift
+++ b/Sources/Rugby/Commands/Cache/Other/Checksums/CombinedChecksum.swift
@@ -41,7 +41,15 @@ extension LocalPod: CombinedChecksum {
     }
 
     private func folder() throws -> Folder {
-        let subpath = path == "." ? name : path
+        let subpath: String
+        switch path {
+        case ".":
+            subpath = name
+        case let filePath where filePath.isFile:
+            subpath = filePath.dropFileName()
+        default:
+            subpath = path
+        }
         return try Folder.current.subfolder(at: subpath)
     }
 

--- a/Sources/Rugby/Common/Extensions/String+File.swift
+++ b/Sources/Rugby/Common/Extensions/String+File.swift
@@ -16,4 +16,16 @@ extension String {
     func basename() -> String {
         filename().components(separatedBy: ".").first ?? self
     }
+
+    /// Drop file name and return folder path
+    func dropFileName() -> String {
+        components(separatedBy: "/")
+            .dropLast()
+            .joined(separator: "/")
+    }
+
+    /// Check if string contains dot
+    var isFile: Bool {
+        contains(".")
+    }
 }


### PR DESCRIPTION
Sometimes `Podfile.lock` can contain a pod with a file source (e.g. `*.podspec`):
```
DEPENDENCIES:
  - Pod1 (from `LocalPods/Pod1`)
  - Pod2 (from `LocalPods/Pod2/Pod2.podspec`)
```
This pull request should fix the issue.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary