### PR TITLE
🐛 Stop all subcommands by pressing ^C

### DIFF
--- a/.github/workflows/regress.yml
+++ b/.github/workflows/regress.yml
@@ -10,11 +10,11 @@ jobs:
       - uses: norio-nomura/action-swiftlint@3.2.1
         with: { args: --strict }
   rugby:
-    runs-on: macos-latest
+    runs-on: macos-11.0
     steps:
       - uses: actions/checkout@v2
       - uses: maxim-lobanov/setup-xcode@v1
-        with: { xcode-version: '12.4' }
+        with: { xcode-version: '12.5.1' }
       - name: Build Rugby
         run: |
           swift build -c release
@@ -28,7 +28,7 @@ jobs:
 #==========================================================================
   cache:
     needs: rugby
-    runs-on: macos-latest
+    runs-on: macos-11.0
     env: { project-directory: ./TestProject }
     steps:
       - uses: actions/checkout@v2
@@ -37,7 +37,7 @@ jobs:
       - run: chmod +x rugby && echo `pwd` >> $GITHUB_PATH
       - run: rugby -h
       - uses: maxim-lobanov/setup-xcode@v1
-        with: { xcode-version: '12.4' }
+        with: { xcode-version: '12.5.1' }
 
       # Prepare TestProject
       - uses: ruby/setup-ruby@v1
@@ -57,7 +57,7 @@ jobs:
 #==========================================================================
   drop:
     needs: rugby
-    runs-on: macos-latest
+    runs-on: macos-11.0
     env: { project-directory: ./TestProject }
     steps:
       - uses: actions/checkout@v2
@@ -66,7 +66,7 @@ jobs:
       - run: chmod +x rugby && echo `pwd` >> $GITHUB_PATH
       - run: rugby -h
       - uses: maxim-lobanov/setup-xcode@v1
-        with: { xcode-version: '12.4' }
+        with: { xcode-version: '12.5.1' }
 
       # Prepare TestProject
       - uses: ruby/setup-ruby@v1
@@ -86,7 +86,7 @@ jobs:
 #==========================================================================
   focus:
     needs: rugby
-    runs-on: macos-latest
+    runs-on: macos-11.0
     env: { project-directory: ./TestProject }
     steps:
       - uses: actions/checkout@v2
@@ -95,7 +95,7 @@ jobs:
       - run: chmod +x rugby && echo `pwd` >> $GITHUB_PATH
       - run: rugby -h
       - uses: maxim-lobanov/setup-xcode@v1
-        with: { xcode-version: '12.4' }
+        with: { xcode-version: '12.5.1' }
 
       # Prepare TestProject
       - uses: ruby/setup-ruby@v1
@@ -115,7 +115,7 @@ jobs:
 #==========================================================================
   plans:
     needs: rugby
-    runs-on: macos-latest
+    runs-on: macos-11.0
     env: { project-directory: ./TestProject }
     steps:
       - uses: actions/checkout@v2
@@ -124,7 +124,7 @@ jobs:
       - run: chmod +x rugby && echo `pwd` >> $GITHUB_PATH
       - run: rugby -h
       - uses: maxim-lobanov/setup-xcode@v1
-        with: { xcode-version: '12.4' }
+        with: { xcode-version: '12.5.1' }
 
       # Prepare TestProject
       - uses: ruby/setup-ruby@v1

--- a/Sources/Rugby/Common/Utils/ProcessMonitor.swift
+++ b/Sources/Rugby/Common/Utils/ProcessMonitor.swift
@@ -1,0 +1,44 @@
+//
+//  ProcessMonitor.swift
+//  Rugby
+//
+//  Created by Vyacheslav Khorkov on 29.10.2021.
+//  Copyright © 2021 Vyacheslav Khorkov. All rights reserved.
+//
+
+import Foundation
+import SwiftShell
+
+/// Synchronise shell subprocesses
+final class ProcessMonitor {
+    static let shared = ProcessMonitor()
+
+    private var isSync = false
+    private let processes = NSHashTable<PrintedAsyncCommand>.weakObjects()
+    private let signalSource = DispatchSource.makeSignalSource(signal: SIGINT, queue: .main)
+
+    // MARK: - Internal Mehtods
+
+    /// Keep links to all process
+    func addProcess(_ process: PrintedAsyncCommand) {
+        processes.add(process)
+    }
+
+    /// Catch SIGINT, clean up all subprocesses, and terminate root process manually
+    static func sync() { shared.sync() }
+
+    // MARK: - Private Methods
+
+    private func sync() {
+        if isSync { fatalError("Process sync already in progress") }
+        isSync = true
+
+        // Make sure the signal does not terminate the application.
+        signal(SIGINT, SIG_IGN)
+        signalSource.setEventHandler { [weak self] in
+            self?.processes.allObjects.forEach { $0.interrupt() }
+            exit(SIGINT)
+        }
+        signalSource.resume()
+    }
+}

--- a/Sources/Rugby/Common/Utils/ShellRunner.swift
+++ b/Sources/Rugby/Common/Utils/ShellRunner.swift
@@ -43,14 +43,18 @@ extension ShellRunner {
         do {
             // Workaround: https://github.com/kareman/SwiftShell/issues/52
             var stdout: String?
-            let readStreams = DispatchWorkItem {
-                stderror = asyncCommand.stderror.read()
+            let readOutStreams = DispatchWorkItem {
                 stdout = asyncCommand.stdout.read()
             }
-            DispatchQueue.global().async(execute: readStreams)
+            let readErrorStreams = DispatchWorkItem {
+                stderror = asyncCommand.stderror.read()
+            }
+            DispatchQueue.global().async(execute: readOutStreams)
+            DispatchQueue.global().async(execute: readErrorStreams)
 
             try asyncCommand.finish()
-            readStreams.wait()
+            readOutStreams.wait()
+            readErrorStreams.wait()
             return stdout ?? ""
         } catch {
             throw ShellError.common(stderror ?? error.localizedDescription)

--- a/Sources/Rugby/Common/Utils/ShellRunner.swift
+++ b/Sources/Rugby/Common/Utils/ShellRunner.swift
@@ -100,14 +100,22 @@ final class ShellRunner {
 
     // MARK: - Wrap Errors
 
-    private let trimmingCharacters: CharacterSet = .newlines.union(.whitespaces)
-
     private func wrapError(_ output: RunOutput) -> Error {
-        ShellError.common(output.stdout.trimmingCharacters(in: trimmingCharacters))
+        ShellError.common(output.stdout.cleanUpOutput())
     }
 
     private func wrapError(_ command: AsyncCommand) -> Error {
-        ShellError.common(command.stderror.read().trimmingCharacters(in: trimmingCharacters))
+        ShellError.common(command.stderror.read().cleanUpOutput())
+    }
+}
+
+private extension String {
+    // This method from SwiftShell
+    func cleanUpOutput() -> String {
+        let afterFirstNewline = firstIndex(of: "\n").map(index(after:))
+        return (afterFirstNewline == nil || afterFirstNewline == endIndex)
+            ? trimmingCharacters(in: .whitespacesAndNewlines)
+            : self
     }
 }
 

--- a/Sources/Rugby/Common/Utils/ShellRunner.swift
+++ b/Sources/Rugby/Common/Utils/ShellRunner.swift
@@ -39,11 +39,13 @@ extension ShellRunner {
         let asyncCommand = SwiftShell.runAsync(currentShell, "-c", commandWithArgs)
         ProcessMonitor.shared.addProcess(asyncCommand)
         do {
+            // Workaround: https://github.com/kareman/SwiftShell/issues/52
+            let output = asyncCommand.stdout.read()
             try asyncCommand.finish()
+            return output
         } catch {
             throw wrapError(asyncCommand)
         }
-        return asyncCommand.stdout.read()
     }
 }
 

--- a/Sources/Rugby/main.swift
+++ b/Sources/Rugby/main.swift
@@ -20,4 +20,6 @@ struct Rugby: ParsableCommand {
         defaultSubcommand: Plans.self
     )
 }
+
+ProcessMonitor.sync()
 Rugby.main()

--- a/TestProject/Fastlane/Xcode
+++ b/TestProject/Fastlane/Xcode
@@ -5,7 +5,7 @@ lane :run_unit_tests do |options|
          scheme: "TestProject",
          xcargs: 'COMPILER_INDEX_STORE_ENABLE=NO SWIFT_COMPILATION_MODE=wholemodule',
          prelaunch_simulator: true,
-         devices: "iPhone 11 (14.4)",
+         devices: "iPhone 11 (14.5)",
          skip_package_dependencies_resolution: true)
 end
 


### PR DESCRIPTION
closes #67

## Known issues

1. Sometimes shell commands still print the interruption log. I couldn't see the ability to mute it with `SwiftShell`:
```
Shell 🐚 bundle exec pod install || bundle exec pod install --repo-update
^C%                                                                             Traceback (most recent call last):
	20: from /Users/swiftyfinch/.rbenv/versions/2.7.2/bin/bundle:23:in `<main>'
	19: from /Users/swiftyfinch/.rbenv/versions/2.7.2/bin/bundle:23:in `load'
	18: from /Users/swiftyfinch/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.2.22/exe/bundle:37:in `<top (required)>'
	17: from /Users/swiftyfinch/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.2.22/lib/bundler/friendly_errors.rb:128:in `with_friendly_errors'
	16: from /Users/swiftyfinch/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.2.22/exe/bundle:49:in `block in <top (required)>'
	15: from /Users/swiftyfinch/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.2.22/lib/bundler/cli.rb:24:in `start'
	14: from /Users/swiftyfinch/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.2.22/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
	13: from /Users/swiftyfinch/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.2.22/lib/bundler/cli.rb:30:in `dispatch'
	12: from /Users/swiftyfinch/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.2.22/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
	11: from /Users/swiftyfinch/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.2.22/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	10: from /Users/swiftyfinch/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.2.22/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
	 9: from /Users/swiftyfinch/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.2.22/lib/bundler/cli.rb:474:in `exec'
	 8: from /Users/swiftyfinch/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.2.22/lib/bundler/cli/exec.rb:28:in `run'
	 7: from /Users/swiftyfinch/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.2.22/lib/bundler/cli/exec.rb:63:in `kernel_load'
	 6: from /Users/swiftyfinch/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/bundler-2.2.22/lib/bundler/cli/exec.rb:63:in `load'
	 5: from /Users/swiftyfinch/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/bin/pod:23:in `<top (required)>'
	 4: from /Users/swiftyfinch/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/bin/pod:23:in `load'
	 3: from /Users/swiftyfinch/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/cocoapods-1.10.1/bin/pod:55:in `<top (required)>'
	 2: from /Users/swiftyfinch/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/cocoapods-1.10.1/lib/cocoapods/command.rb:50:in `run'
	 1: from /Users/swiftyfinch/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/cocoapods-1.10.1/lib/cocoapods/command.rb:178:in `verify_xcode_license_approved!'
/Users/swiftyfinch/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/cocoapods-1.10.1/lib/cocoapods/command.rb:178:in ``': Interrupt
```
2. Sometimes need to press `Enter` after an interruption to see the prompt.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary