### PR TITLE
Fix an error if the default shell is fish.

### DIFF
--- a/Sources/Rugby/Common/XcodeProj/Scheme/XcodeProj+RemoveSchemes.swift
+++ b/Sources/Rugby/Common/XcodeProj/Scheme/XcodeProj+RemoveSchemes.swift
@@ -60,7 +60,7 @@ extension XcodeProj {
             try? sharedSchemes?.file(at: $0 + ".xcscheme").delete()
         }
 
-        let username = try shell("echo ${USER}").trimmingCharacters(in: .whitespacesAndNewlines)
+        let username = try shell("echo $USER").trimmingCharacters(in: .whitespacesAndNewlines)
         schemesForRemove.forEach {
             let userSchemesFolder = try? Folder(path: projectPath + "/xcuserdata/\(username).xcuserdatad/xcschemes")
             try? userSchemesFolder?.file(at: $0 + ".xcscheme").delete()


### PR DESCRIPTION
<!--
    Thanks for contributing to the Rugby! 🎉

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
    
    Provide links to an existing issue or external references/discussions, if appropriate.
-->

Hello. Rugby is very nice tool!
I've found the issue so sent this pull request.

Rugby cache command occurred error if fish shell is default.
I get the following error.

```fish
[2s] Prepare ✓
[1s] Build ✓
[1s] Integration ✓
Clean up Remove schemes
⛔️ Error: fish: Variables cannot be bracketed. In fish, please use {$USER}.
echo ${USER} 
      ^

🚑 Call doctor for more help: rugby doctor
```

This issue seems to be due to the assumption that the shell command is bash or zsh.
Therefore, by pinning the execution shell to bash is resolve this issue.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary