### PR TITLE
🚀 Added ability to use Plans command recursively

### DIFF
--- a/Docs/Plans.md
+++ b/Docs/Plans.md
@@ -37,15 +37,9 @@ rugby example
 ```yml
 # The first plan in the file always run by default
 - usual:
-  # 🐚 Optionally you can generate project if you use Xcodegen or something like that
-  - command: shell
-    run: xcodegen
-    verbose: false
-
-  # 🐚 Also, you can install pods before each rugby call right here
-  - command: shell
-    run: bundle exec pod install # Or you can use any shell command
-    verbose: true
+  # Reuse another plan from this file
+  - command: plans
+    name: base
 
   # 🏈 The first Rugby command without arguments like: $ rugby cache
   - command: cache
@@ -79,8 +73,23 @@ rugby example
     project: TestProject/TestProject.xcodeproj
 
 
+# Base plan which you can use in other plans
+- base:
+  # 🐚 Optionally you can generate project if you use Xcodegen or something like that
+  #- command: shell
+  #  run: xcodegen
+  #  verbose: false
+  
+  # 🐚 Also, you can install pods before each rugby call right here
+  - command: shell
+    run: pods -q # github.com/swiftyfinch/Pods or you can use any shell command
+    verbose: true
+  
+
 # Also, you can use another custom plan: $ rugby --plan unit
 - unit:
+  - command: plans
+    name: base
   - command: cache
     exclude: [Alamofire]
   - command: drop

--- a/Sources/Rugby/Commands/Plan/Command/PlanRun.swift
+++ b/Sources/Rugby/Commands/Plan/Command/PlanRun.swift
@@ -30,7 +30,7 @@ extension Plans {
         } else if let foundPlan = plans.first(where: { $0.name == plan }) {
             return foundPlan
         } else {
-            throw PlanError.cantFindPlan
+            throw PlanError.cantFindPlan(plan ?? .firstPlan)
         }
     }
 
@@ -93,4 +93,8 @@ extension Plans {
         RugbyPrinter(title: "Plans ✈️ ", logFile: logFile, verbose: .verbose)
             .print("\(plan.yellow)")
     }
+}
+
+private extension String {
+    static let firstPlan = "first"
 }

--- a/Sources/Rugby/Commands/Plan/Parser/DecodableModels/PlansDecodable.swift
+++ b/Sources/Rugby/Commands/Plan/Parser/DecodableModels/PlansDecodable.swift
@@ -1,0 +1,19 @@
+//
+//  PlansDecodable.swift
+//  Rugby
+//
+//  Created by Vyacheslav Khorkov on 09.11.2021.
+//  Copyright © 2021 Vyacheslav Khorkov. All rights reserved.
+//
+
+import Foundation
+
+struct PlansDecodable: Decodable {
+    let name: String
+}
+
+extension PlansReference {
+    init(from decodable: PlansDecodable) {
+        self.name = decodable.name
+    }
+}

--- a/Sources/Rugby/Commands/Plan/Parser/DecodableModels/ShellDecodable.swift
+++ b/Sources/Rugby/Commands/Plan/Parser/DecodableModels/ShellDecodable.swift
@@ -10,3 +10,10 @@ struct ShellDecodable: Decodable {
     let run: String
     @BoolableIntDecodable var verbose: Int?
 }
+
+extension Shell {
+    init(from decodable: ShellDecodable) {
+        self.run = decodable.run
+        self.verbose = decodable.verbose ?? 0
+    }
+}

--- a/Sources/Rugby/Commands/Plan/Parser/Errors/PlanError.swift
+++ b/Sources/Rugby/Commands/Plan/Parser/Errors/PlanError.swift
@@ -12,7 +12,7 @@ enum PlanError: Error, LocalizedError {
     case incorrectYMLFormat
     case incorrectCommandName
     case incorrectArgument
-    case cantFindPlan
+    case cantFindPlan(String)
 
     var errorDescription: String? {
         switch self {
@@ -22,8 +22,8 @@ enum PlanError: Error, LocalizedError {
             return "Incorrect command name in plans.yml."
         case .incorrectArgument:
             return "Incorrect arguments in plans.yml."
-        case .cantFindPlan:
-            return "Couldn't find selected plan."
+        case .cantFindPlan(let plan):
+            return "Couldn't find ✈️ \(plan) plan."
         }
     }
 }

--- a/Sources/Rugby/Commands/Plan/Parser/PlanParser.swift
+++ b/Sources/Rugby/Commands/Plan/Parser/PlanParser.swift
@@ -39,7 +39,7 @@ struct PlanParser {
 
 extension PlanParser {
     private enum Commands: String {
-        case cache, focus, drop, shell
+        case cache, focus, drop, shell, plans
     }
 
     private func parseCommand(_ dictionary: [String: Any]) throws -> Command {
@@ -61,6 +61,9 @@ extension PlanParser {
         case .shell:
             let decodable = try JSONDecoder().decode(ShellDecodable.self, from: dataArguments)
             return Shell(from: decodable)
+        case .plans:
+            let decodable = try JSONDecoder().decode(PlansDecodable.self, from: dataArguments)
+            return PlansReference(from: decodable)
         }
     }
 

--- a/Sources/Rugby/Commands/Plan/Parser/PlanParser.swift
+++ b/Sources/Rugby/Commands/Plan/Parser/PlanParser.swift
@@ -59,8 +59,8 @@ extension PlanParser {
             let decodable = try JSONDecoder().decode(DropDecodable.self, from: dataArguments)
             return Drop(from: decodable)
         case .shell:
-            let yml = try JSONDecoder().decode(ShellDecodable.self, from: dataArguments)
-            return Shell(run: yml.run, verbose: yml.verbose ?? 0)
+            let decodable = try JSONDecoder().decode(ShellDecodable.self, from: dataArguments)
+            return Shell(from: decodable)
         }
     }
 

--- a/Sources/Rugby/Commands/Plan/Subcommands/PlansExample.swift
+++ b/Sources/Rugby/Commands/Plan/Subcommands/PlansExample.swift
@@ -49,14 +49,9 @@ struct PlansExample: ParsableCommand {
 
         # The first plan in the file always run by default
         - usual:
-          # 🐚 Optionally you can generate project if you use Xcodegen or something like that
-          #- command: shell
-          #  run: xcodegen
-
-          # 🐚 Also, you can install pods before each rugby call right here
-          - command: shell
-            run: bundle exec pod install # Or you can use any shell command
-            verbose: false
+          # Reuse another plan from this file
+          - command: plans
+            name: base
 
           # 🏈 The first Rugby command without arguments like: $ rugby cache
           - command: cache
@@ -85,14 +80,28 @@ struct PlansExample: ParsableCommand {
 
           # 🗑 And so on: $ rugby drop -i "TestProject" -p TestProject/TestProject.xcodeproj
           - command: drop
-            targets:
-              - ^TestProject$
+            targets: [^TestProject$] # Alternative array syntax
             invert: true
             project: TestProject/TestProject.xcodeproj
 
 
+        # Base plan which you can use in other plans
+        - base:
+          # 🐚 Optionally you can generate project if you use Xcodegen or something like that
+          #- command: shell
+          #  run: xcodegen
+          #  verbose: false
+
+          # 🐚 Also, you can install pods before each rugby call right here
+          - command: shell
+            run: bundle exec pod install # Or you can use any shell command
+            verbose: false
+
+
         # Also, you can use another custom plan: $ rugby --plan unit
         - unit:
+          - command: plans
+            name: base
           - command: cache
             exclude: [Alamofire]
           - command: drop

--- a/Sources/Rugby/Commands/Plan/Subcommands/PlansReference.swift
+++ b/Sources/Rugby/Commands/Plan/Subcommands/PlansReference.swift
@@ -1,0 +1,19 @@
+//
+//  PlansReference.swift
+//  Rugby
+//
+//  Created by Vyacheslav Khorkov on 12.11.2021.
+//  Copyright © 2021 Vyacheslav Khorkov. All rights reserved.
+//
+
+import Files
+
+struct PlansReference {
+    let name: String
+}
+
+extension PlansReference: Command {
+    mutating func run(logFile: File) throws -> Metrics? {
+        fatalError("This method must be never called.")
+    }
+}


### PR DESCRIPTION
Added the ability to use `Plans` command in `.rugby/plans.yml` fie.
```yml
- dev:
  - command: plans
    run: base # And use base plan here
  - command: cache

- base: # Preapre base plan
  - command: shell
    run: xcodegen
    verbose: false
  - command: shell
    run: pods -q
```

Beware of recursion 😱

See the issue for more info:
Closes #68 

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary