### PR TITLE
🐛 Reset projects cache after shell command

### DIFF
--- a/Sources/Rugby/Commands/Plan/Subcommands/PlansShell.swift
+++ b/Sources/Rugby/Commands/Plan/Subcommands/PlansShell.swift
@@ -23,6 +23,12 @@ struct Shell: Command {
             }
         }
         progress.done()
+        resetProjectsCache()
         return nil
+    }
+
+    // Shell command can modify projects
+    func resetProjectsCache() {
+        ProjectProvider.shared.reset()
     }
 }

--- a/Sources/Rugby/Common/XcodeProj/Project/ProjectProvider.swift
+++ b/Sources/Rugby/Common/XcodeProj/Project/ProjectProvider.swift
@@ -21,4 +21,8 @@ final class ProjectProvider {
         cache[path] = project
         return project
     }
+
+    func reset() {
+        cache = [:]
+    }
 }


### PR DESCRIPTION
## Description
Shell commands can modify Xcode projects.
Need to reset cache after each one for stable execution.

## References
Closes #90

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

❤️ Thanks for contributing to the Rugby!
