### PR TITLE
🐛 Escape SYMROOT variable

### DIFF
--- a/Sources/Rugby/Commands/Cache/Other/Build/XcodeBuild.swift
+++ b/Sources/Rugby/Commands/Cache/Other/Build/XcodeBuild.swift
@@ -19,7 +19,7 @@ struct XcodeBuild {
             "-project \(project)",
             "-scheme \(scheme)",
             "-sdk \(sdk.xcodebuild)",
-            "SYMROOT=$(PWD)/" + .buildFolder
+            "SYMROOT=\"$(PWD)/\(String.buildFolder)\""
         ]
         arguments.append(contentsOf: xcargs)
 


### PR DESCRIPTION
### Description
Need to escape SYMROOT variable because some paths can contain spaces.

### References
Closes https://github.com/swiftyfinch/Rugby/issues/87#issuecomment-982652567

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

❤️ Thanks for contributing to the Rugby!
