### PR TITLE
🐛 Make parsing external source more flexible

### DIFF
--- a/Sources/Rugby/Commands/Cache/Other/Lockfile/Lockfile.swift
+++ b/Sources/Rugby/Commands/Cache/Other/Lockfile/Lockfile.swift
@@ -36,8 +36,11 @@ struct Lockfile {
     }
 
     private static func parseExternalSources(_ object: [String: Any]) throws -> [String: [String: String]] {
-        try ((object[.externalSources] ?? [:]) as? [String: [String: String]])
+        try ((object[.externalSources] ?? [:]) as? [String: [String: Any]])
             .unwrap(orThrow: LockFileError.incorrectObject(.externalSources))
+            .mapDictionary { key, value in
+                (key, value.mapDictionary { ($0.key, String(describing: $0.value)) })
+            }
     }
 
     private static func parseSpecRepos(_ object: [String: Any]) throws -> [String: [String]] {


### PR DESCRIPTION
### Description
Made parsing `EXTERNAL SOURCES` in `Podfile.lock` more flexible.
Probably, there can be non `String` values.

### References
Close #113

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

❤️ Thanks for contributing to the 🏈 Rugby!
