### PR TITLE
🐛 Use absolute paths without Xcode variables

### DIFF
--- a/Sources/Rugby/Commands/Cache/Steps/CacheIntegrateStep.swift
+++ b/Sources/Rugby/Commands/Cache/Steps/CacheIntegrateStep.swift
@@ -27,7 +27,7 @@ struct CacheIntegrateStep: Step {
 
     func run(_ targets: Set<String>) throws {
         try progress.spinner("Update paths to built pods") {
-            try CacheIntegration(cacheFolder: .cacheFolder,
+            try CacheIntegration(cacheFolder: .cacheFolder(currentPath: Folder.current.path),
                                  builtTargets: targets).replacePathsToCache()
         }
         done()

--- a/Sources/Rugby/Common/Environment/String+Env.swift
+++ b/Sources/Rugby/Common/Environment/String+Env.swift
@@ -9,6 +9,7 @@
 extension String {
 
     // MARK: - Output
+
     static let finalMessage = "Let's roll 🏈".green
     static let separator = "---------------------------------".yellow
 
@@ -41,6 +42,9 @@ extension String {
     static let buildLog = supportFolder + "/build.log"
     static let buildFolder = supportFolder + "/build"
     static let cacheFile = supportFolder + "/cache.yml"
-    static let cacheFolder: String =
-        "${PODS_ROOT}/../" + supportFolder + "/build/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}"
+
+    private static let cacheFolderName = "${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}"
+    static func cacheFolder(currentPath: String) -> String {
+        "\(currentPath)\(buildFolder)/\(cacheFolderName)"
+    }
 }


### PR DESCRIPTION
### Description
Use absolute paths without Xcode variables.
I didn't add new tests for this fix, but the issue can be reproduced with these changes in `Podfile`:
```diff
-  use_frameworks!
+ pod 'hippy', '2.11.6'
```

### References
Closes #125

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary

❤️ Thanks for contributing to the 🏈 Rugby!
