### PR TITLE
🔭 `[Beta]` Add arch to product directory

### DIFF
--- a/Sources/Rugby/Commands/Cache/Command/CacheHeader.swift
+++ b/Sources/Rugby/Commands/Cache/Command/CacheHeader.swift
@@ -14,7 +14,7 @@ struct Cache: ParsableCommand {
     @Option(name: .shortAndLong,
             parsing: .upToNextOption,
             help: "Build architectures. (default: sim \(ARCH.x86_64), ios \(ARCH.arm64))") var arch: [String] = []
-    @Option(name: .shortAndLong, help: "Build configuration. (default: \(CONFIG.debug))") var config: String?
+    @Option(name: .shortAndLong, help: "Build configuration.") var config = CONFIG.debug
     @Flag(name: .long, help: "Add bitcode for archive builds.") var bitcode = false
     @Flag(name: .shortAndLong, help: "Keep Pods group in project.") var keepSources = false
     @Option(name: .shortAndLong, parsing: .upToNextOption, help: "Exclude pods from cache.") var exclude: [String] = []

--- a/Sources/Rugby/Commands/Cache/Command/CacheRun.swift
+++ b/Sources/Rugby/Commands/Cache/Command/CacheRun.swift
@@ -15,9 +15,6 @@ extension Cache: Command {
         if !arch.isEmpty, sdk.count != arch.count { throw CacheError.incorrectArchCount }
         if arch.isEmpty { arch = sdk.map(\.defaultARCH) /* Set default arch for each sdk */ }
 
-        // For build configuration name use Debug by default.
-        if config == nil { config = CONFIG.debug }
-
         let metrics = CacheMetrics(project: String.podsProject.basename())
         let factory = CacheStepsFactory(command: self, metrics: metrics, logFile: logFile)
         let info = try factory.prepare(.buildTarget)

--- a/Sources/Rugby/Commands/Cache/Other/Build/XcodeBuild.swift
+++ b/Sources/Rugby/Commands/Cache/Other/Build/XcodeBuild.swift
@@ -12,26 +12,23 @@ struct XcodeBuild {
     let project: String
     let scheme: String
     let sdk: SDK
-    let arch: String?
-    let config: String?
+    let arch: String
+    let config: String
     let xcargs: [String]
 
     func build() throws {
+        let escapedConfig = config.shellFriendly
         let currentFolder = Folder.current.path.shellFriendly
         var arguments = [
             "-project \(project)",
             "-scheme \(scheme)",
             "-sdk \(sdk.xcodebuild)",
-            "SYMROOT=\(currentFolder)\(String.buildFolder)"
+            "-config \(escapedConfig)",
+            "ARCHS=\(arch)",
+            "SYMROOT=\(currentFolder)\(String.buildFolder)",
+            "CONFIGURATION_BUILD_DIR=\(currentFolder)\(String.buildFolder)/\(escapedConfig)-\(sdk.xcodebuild)-\(arch)"
         ]
         arguments.append(contentsOf: xcargs)
-
-        if let arch = arch {
-            arguments.append("ARCHS=\(arch)")
-        }
-        if let config = config {
-            arguments.append("-config \(config.shellFriendly)")
-        }
         arguments.append("| tee " + .rawBuildLog)
 
         try XcodeBuildRunner(rawLogPath: .rawBuildLog, logPath: .buildLog).run(

--- a/Sources/Rugby/Commands/Cache/Other/Errors/CacheError.swift
+++ b/Sources/Rugby/Commands/Cache/Other/Errors/CacheError.swift
@@ -12,6 +12,7 @@ import Rainbow
 enum CacheError: Error, LocalizedError {
     case cantFindPodsTargets
     case cantFindXcodeCommandLineTools
+    case cantGetSwiftVersion
     case buildFailed([String])
     case incorrectArchCount
 
@@ -23,6 +24,9 @@ enum CacheError: Error, LocalizedError {
                 + "🚑 Try to call pod install.".yellow
         case .cantFindXcodeCommandLineTools:
             output = "Couldn't find Xcode CLT.\n".red
+                + "🚑 Check Xcode Preferences → Locations → Command Line Tools.".yellow
+        case .cantGetSwiftVersion:
+            output = "Couldn't get Swift version".red
                 + "🚑 Check Xcode Preferences → Locations → Command Line Tools.".yellow
         case .buildFailed(let errors):
             let buildCommand = "cat \(String.buildLog)"

--- a/Sources/Rugby/Commands/Cache/Other/PatchConfigs/CacheIntegration.swift
+++ b/Sources/Rugby/Commands/Cache/Other/PatchConfigs/CacheIntegration.swift
@@ -17,7 +17,7 @@ struct CacheIntegration {
         let originalDirs = ["PODS_CONFIGURATION_BUILD_DIR", "BUILT_PRODUCTS_DIR"].joined(separator: "|")
         let suffixPods = builtTargets.map { $0.escapeForRegex() }.joined(separator: "|")
         let fileRegex = [#".*-resources\.sh"#, #".*\.xcconfig"#, #".*-frameworks\.sh"#].joined(separator: "|")
-        try FilePatcher().replace(#"\$\{(\#(originalDirs))\}(?=\/(\#(suffixPods))("|\s|\/))"#,
+        try FilePatcher().replace(#"\$\{(\#(originalDirs))\}\/(\#(suffixPods)).*?(?=\/|"|\s)"#,
                                   with: cacheFolder,
                                   inFilesByRegEx: "(\(fileRegex))",
                                   folder: supportFilesFolder)

--- a/Sources/Rugby/Commands/Cache/Steps/Prepare/CachePrepareStep.swift
+++ b/Sources/Rugby/Commands/Cache/Steps/Prepare/CachePrepareStep.swift
@@ -14,7 +14,7 @@ struct CachePrepareStep: Step {
         let targets: Set<String>
         let buildInfo: BuildInfo
         let products: [String]
-        let swiftVersion: String?
+        let swiftVersion: String
     }
 
     let verbose: Int

--- a/Sources/Rugby/Commands/Plan/Parser/DecodableModels/CacheDecodable.swift
+++ b/Sources/Rugby/Commands/Plan/Parser/DecodableModels/CacheDecodable.swift
@@ -26,7 +26,7 @@ struct CacheDecodable: Decodable {
 extension Cache {
     init(from decodable: CacheDecodable) {
         self.arch = decodable.arch ?? []
-        self.config = decodable.config
+        self.config = decodable.config ?? CONFIG.debug
         self.sdk = decodable.sdk ?? [.sim]
         self.bitcode = decodable.bitcode ?? false
         self.keepSources = decodable.keepSources ?? false

--- a/Sources/Rugby/Common/Environment/String+Env.swift
+++ b/Sources/Rugby/Common/Environment/String+Env.swift
@@ -37,5 +37,5 @@ extension String {
     static let buildFolder = supportFolder + "/build"
     static let cacheFile = supportFolder + "/cache.yml"
     static let cacheFolder: String =
-        "${PODS_ROOT}/../" + supportFolder + "/build/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}"
+        "${PODS_ROOT}/../" + supportFolder + "/build/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}"
 }

--- a/TestProject/TestProject/TestProject.xcodeproj/project.pbxproj
+++ b/TestProject/TestProject/TestProject.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		0CB45CA5332BECA822C99B3F /* Pods-TestProject.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestProject.debug.xcconfig"; path = "../../Pods/Target Support Files/Pods-TestProject/Pods-TestProject.debug.xcconfig"; sourceTree = "<group>"; };
 		0F266C3A158B4525AF7D2E8D /* Pods-TestProject.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestProject.staging.xcconfig"; path = "../../Pods/Target Support Files/Pods-TestProject/Pods-TestProject.staging.xcconfig"; sourceTree = "<group>"; };
 		0F7CAE2DB74929BDDB77D087 /* Pods-TestProject.staging tests.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestProject.staging tests.xcconfig"; path = "../../Pods/Target Support Files/Pods-TestProject/Pods-TestProject.staging tests.xcconfig"; sourceTree = "<group>"; };
+		14CC5668D839F208983AA107 /* Pods-TestProject.staging with spaces.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestProject.staging with spaces.xcconfig"; path = "../../Pods/Target Support Files/Pods-TestProject/Pods-TestProject.staging with spaces.xcconfig"; sourceTree = "<group>"; };
 		1708F6F52543CBD43477C925 /* Pods-TestProject-TestProjectUITests.staging test.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestProject-TestProjectUITests.staging test.xcconfig"; path = "../../Pods/Target Support Files/Pods-TestProject-TestProjectUITests/Pods-TestProject-TestProjectUITests.staging test.xcconfig"; sourceTree = "<group>"; };
 		193FF2D8C94D11037185F80A /* Pods-TestProject.staging test.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestProject.staging test.xcconfig"; path = "../../Pods/Target Support Files/Pods-TestProject/Pods-TestProject.staging test.xcconfig"; sourceTree = "<group>"; };
 		1CA92A3395365A0F83AA056B /* Pods-TestProjectTests.staging tests.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestProjectTests.staging tests.xcconfig"; path = "../../Pods/Target Support Files/Pods-TestProjectTests/Pods-TestProjectTests.staging tests.xcconfig"; sourceTree = "<group>"; };
@@ -85,7 +86,9 @@
 		96549C9E47719FAFA2A2FC49 /* Pods-TestProjectTests.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestProjectTests.staging.xcconfig"; path = "../../Pods/Target Support Files/Pods-TestProjectTests/Pods-TestProjectTests.staging.xcconfig"; sourceTree = "<group>"; };
 		9C28EAA1A247644F3649D48D /* Pods-TestProject-TestProjectUITests.staging.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestProject-TestProjectUITests.staging.xcconfig"; path = "../../Pods/Target Support Files/Pods-TestProject-TestProjectUITests/Pods-TestProject-TestProjectUITests.staging.xcconfig"; sourceTree = "<group>"; };
 		B4A7867F56CFA4C34A22D656 /* Pods-TestProjectTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestProjectTests.debug.xcconfig"; path = "../../Pods/Target Support Files/Pods-TestProjectTests/Pods-TestProjectTests.debug.xcconfig"; sourceTree = "<group>"; };
+		C0FF5B499D4A3B76E8CBBAFB /* Pods-TestProjectTests.staging with spaces.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestProjectTests.staging with spaces.xcconfig"; path = "../../Pods/Target Support Files/Pods-TestProjectTests/Pods-TestProjectTests.staging with spaces.xcconfig"; sourceTree = "<group>"; };
 		CE81E7344ADAD131F00E9E5E /* Pods_TestProject_TestProjectUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TestProject_TestProjectUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D5DC2F4A2A925832E1FCB35F /* Pods-TestProject-TestProjectUITests.staging with spaces.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestProject-TestProjectUITests.staging with spaces.xcconfig"; path = "../../Pods/Target Support Files/Pods-TestProject-TestProjectUITests/Pods-TestProject-TestProjectUITests.staging with spaces.xcconfig"; sourceTree = "<group>"; };
 		F3C2C078A9C7FF276DB89683 /* Pods-TestProject-TestProjectUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-TestProject-TestProjectUITests.debug.xcconfig"; path = "../../Pods/Target Support Files/Pods-TestProject-TestProjectUITests/Pods-TestProject-TestProjectUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		F976CB1E6FFBB1F3703F2DB5 /* Pods_TestProjectTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_TestProjectTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -226,6 +229,9 @@
 				0F7CAE2DB74929BDDB77D087 /* Pods-TestProject.staging tests.xcconfig */,
 				4F66484DA8BBBC489F3F18A9 /* Pods-TestProject-TestProjectUITests.staging tests.xcconfig */,
 				1CA92A3395365A0F83AA056B /* Pods-TestProjectTests.staging tests.xcconfig */,
+				14CC5668D839F208983AA107 /* Pods-TestProject.staging with spaces.xcconfig */,
+				D5DC2F4A2A925832E1FCB35F /* Pods-TestProject-TestProjectUITests.staging with spaces.xcconfig */,
+				C0FF5B499D4A3B76E8CBBAFB /* Pods-TestProjectTests.staging with spaces.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -432,7 +438,7 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
-				$SRCROOT/TestProject/R.generated.swift,
+				"$SRCROOT/TestProject/R.generated.swift",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1013,7 +1019,7 @@
 		};
 		2CCFF7E02711EB1C008B313B /* Staging With Spaces */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0F7CAE2DB74929BDDB77D087 /* Pods-TestProject.staging tests.xcconfig */;
+			baseConfigurationReference = 14CC5668D839F208983AA107 /* Pods-TestProject.staging with spaces.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -1038,7 +1044,7 @@
 		};
 		2CCFF7E12711EB1C008B313B /* Staging With Spaces */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4F66484DA8BBBC489F3F18A9 /* Pods-TestProject-TestProjectUITests.staging tests.xcconfig */;
+			baseConfigurationReference = D5DC2F4A2A925832E1FCB35F /* Pods-TestProject-TestProjectUITests.staging with spaces.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = TestProjectUITests/Info.plist;
@@ -1058,7 +1064,7 @@
 		};
 		2CCFF7E22711EB1C008B313B /* Staging With Spaces */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1CA92A3395365A0F83AA056B /* Pods-TestProjectTests.staging tests.xcconfig */;
+			baseConfigurationReference = C0FF5B499D4A3B76E8CBBAFB /* Pods-TestProjectTests.staging with spaces.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;


### PR DESCRIPTION
### Description
Added arch to products directory.
Now we can build with the same arch for different sdks. For example:
```shell
rugby -s sim sim ios -a x86_64 arm64 arm64
```
```
Debug-iphoneos-arm64
Debug-iphonesimulator-arm64
Debug-iphonesimulator-x86_64
```

But I think we still need the better api.

### References
#93 #123

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary

❤️ Thanks for contributing to the 🏈 Rugby!
