### PR TITLE
🐛 Use another way to identify if a project already use 🏈 Rugby

### DIFF
--- a/Sources/Rugby/Commands/Cache/Other/Errors/CacheError.swift
+++ b/Sources/Rugby/Commands/Cache/Other/Errors/CacheError.swift
@@ -10,7 +10,7 @@ import Foundation
 import Rainbow
 
 enum CacheError: Error, LocalizedError {
-    case cantFindPodsTargets
+    case projectAlreadyPatched
     case cantFindXcodeCommandLineTools
     case buildFailed([String])
     case incorrectArchCount
@@ -18,8 +18,8 @@ enum CacheError: Error, LocalizedError {
     var errorDescription: String? {
         let output: String
         switch self {
-        case .cantFindPodsTargets:
-            output = "Couldn't find pods targets.\n".red
+        case .projectAlreadyPatched:
+            output = "Project already patched.\n".red
                 + "🚑 Try to call pod install.".yellow
         case .cantFindXcodeCommandLineTools:
             output = "Couldn't find Xcode CLT.\n".red

--- a/Sources/Rugby/Commands/Cache/Steps/CacheCleanupStep.swift
+++ b/Sources/Rugby/Commands/Cache/Steps/CacheCleanupStep.swift
@@ -71,6 +71,7 @@ struct CacheCleanupStep: Step {
             try project.removeSchemes(pods: targets, projectPath: .podsProject)
 
             try progress.spinner("Save project") {
+                project.pbxproj.main.set(buildSettingsKey: .rugbyPatched, value: String.yes)
                 try project.write(pathString: .podsProject, override: true)
             }
 

--- a/Sources/Rugby/Commands/Cache/Steps/Prepare/CachePrepareStep.swift
+++ b/Sources/Rugby/Commands/Cache/Steps/Prepare/CachePrepareStep.swift
@@ -46,6 +46,10 @@ extension CachePrepareStep {
         }
         metrics.compileFilesCount.before = project.pbxproj.buildFiles.count
         metrics.targetsCount.before = project.pbxproj.main.targets.count
+
+        let projectPatched = project.pbxproj.main.contains(buildSettingsKey: .rugbyPatched)
+        if projectPatched { throw CacheError.projectAlreadyPatched }
+
         let factory = CacheSubstepFactory(progress: progress, command: command, metrics: metrics)
         let selectedPods = try factory.selectPods(project)
         let (buildInfo, swiftVersion) = try factory.findBuildPods(selectedPods)

--- a/Sources/Rugby/Commands/Cache/Steps/Prepare/Substeps/BuildTargets.swift
+++ b/Sources/Rugby/Commands/Cache/Steps/Prepare/Substeps/BuildTargets.swift
@@ -17,8 +17,6 @@ extension CacheSubstepFactory {
                            selectedPods: Set<String>,
                            buildPods: Set<String>)) throws -> (Set<PBXTarget>, Set<String>) {
             let selectedPodsChain = input.project.buildPodsChain(pods: input.selectedPods)
-            guard selectedPodsChain.count >= input.selectedPods.count else { throw CacheError.cantFindPodsTargets }
-
             let additionalBuildTargets = Set(selectedPodsChain.map(\.name)).subtracting(input.selectedPods)
             if !additionalBuildTargets.isEmpty {
                 progress.print(additionalBuildTargets, text: "Additional build targets", level: .vv)

--- a/Sources/Rugby/Common/Environment/String+Env.swift
+++ b/Sources/Rugby/Common/Environment/String+Env.swift
@@ -27,6 +27,11 @@ extension String {
 
     static let history = supportFolder + "/history"
 
+    // MARK: - Xcode Project Variables
+
+    static let rugbyPatched = "RUGBY_PATCHED"
+    static let yes: Any = "YES"
+
     // MARK: - Cache command
 
     static let defaultXcodeCLTPath = "/Library/Developer/CommandLineTools"

--- a/Sources/Rugby/Common/XcodeProj/Project/PBXProject+BuildSettings.swift
+++ b/Sources/Rugby/Common/XcodeProj/Project/PBXProject+BuildSettings.swift
@@ -1,0 +1,23 @@
+//
+//  PBXProject+BuildSettings.swift
+//  Rugby
+//
+//  Created by Vyacheslav Khorkov on 04.02.2022.
+//  Copyright © 2021 Vyacheslav Khorkov. All rights reserved.
+//
+
+import XcodeProj
+
+extension PBXProject {
+    func contains(buildSettingsKey: String) -> Bool {
+        buildConfigurationList.buildConfigurations.contains {
+            $0.buildSettings[buildSettingsKey] != nil
+        }
+    }
+
+    func set(buildSettingsKey: String, value: Any) {
+        buildConfigurationList.buildConfigurations.forEach {
+            $0.buildSettings[buildSettingsKey] = value
+        }
+    }
+}


### PR DESCRIPTION
### Description
Before using the **cache** command we need to know if the project already has been patched.
The legacy solution was:
```swift
guard selectedPodsChain.count >= input.selectedPods.count else { throw CacheError.cantFindPodsTargets }
```
But there are some cases when it just doesn't work.

I think the better way is to add a concrete variable to the **Pods** project. Then check if that variable already exists and show an error with a suggestion to call `pod install`.

### References
None

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary

❤️ Thanks for contributing to the 🏈 Rugby!
