### PR TITLE
🐛 Exclude xcframeworks after finding all build targets

### DIFF
--- a/Sources/Rugby/Commands/Cache/Steps/Prepare/CachePrepareStep.swift
+++ b/Sources/Rugby/Commands/Cache/Steps/Prepare/CachePrepareStep.swift
@@ -51,11 +51,12 @@ extension CachePrepareStep {
         if projectPatched { throw CacheError.projectAlreadyPatched }
 
         let factory = CacheSubstepFactory(progress: progress, command: command, metrics: metrics)
-        let selectedPods = try factory.selectPods(project)
+        let (selectedPods, excludedPods) = try factory.selectPods(project)
         let (buildInfo, swiftVersion) = try factory.findBuildPods(selectedPods)
-        let (selectedTargets, buildTargets) = try factory.buildTargets((project: project,
+        var (selectedTargets, buildTargets) = try factory.buildTargets((project: project,
                                                                         selectedPods: selectedPods,
                                                                         buildPods: buildInfo.pods))
+        selectedTargets = selectedTargets.filter { !excludedPods.contains($0.name) }
         if !buildTargets.isEmpty {
             try factory.addBuildTarget(.init(target: buildTarget, project: project, dependencies: buildTargets))
         }

--- a/Sources/Rugby/Commands/Cache/Steps/Prepare/Substeps/SelectPods.swift
+++ b/Sources/Rugby/Commands/Cache/Steps/Prepare/Substeps/SelectPods.swift
@@ -16,7 +16,7 @@ extension CacheSubstepFactory {
         let metrics: Metrics
         let podsProvider = PodsProvider.shared
 
-        func run(_ project: XcodeProj) throws -> Set<String> {
+        func run(_ project: XcodeProj) throws -> (selected: Set<String>, excluded: Set<String>) {
             let pods: Set<String>
             if !command.focus.isEmpty {
                 let allPods = try podsProvider.podsNames()
@@ -44,7 +44,7 @@ extension CacheSubstepFactory {
             }
 
             metrics.podsCount.before = pods.count
-            return filteredPods
+            return (filteredPods, excluded)
         }
     }
 }


### PR DESCRIPTION
### Description
Sometimes XCFrameworks weren't excluded correctly.
It was so, when some of XCFrameworks were dependencies of build targets.
In this request all XCFrameworks should be excluded from build targets after finding all of them.

### References
None

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary

❤️ Thanks for contributing to the 🏈 Rugby!
