### PR TITLE
🐛 Exclude remaining targets explicitly

### DIFF
--- a/Sources/Rugby/Commands/Cache/Steps/CacheCleanupStep.swift
+++ b/Sources/Rugby/Commands/Cache/Steps/CacheCleanupStep.swift
@@ -60,7 +60,11 @@ struct CacheCleanupStep: Step {
         }
 
         progress.print("Remove built pods".yellow, level: .vv)
-        var removeBuiltPods = project.removeDependencies(names: targets, exclude: command.exclude)
+        // Adding all remaining targets to exclude. It needs for adding transitive dependencies explicitly.
+        let exclude = Set(project.pbxproj.main.targets.map(\.name))
+            .subtracting(targets)
+            .union(command.exclude)
+        var removeBuiltPods = project.removeDependencies(names: targets, exclude: Array(exclude))
         targets.forEach {
             removeBuiltPods = project.removeTarget(name: $0) || removeBuiltPods
         }


### PR DESCRIPTION
### Description
Sometimes during clean step Rugby removes necessary dependencies.
That because CocoaPods use implicit dependencies, and if we remove one of them some transitive dependencies can be removed alltogether. So we need to make all dependencies explicit.

### References
None

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary

❤️ Thanks for contributing to the 🏈 Rugby!
