### PR TITLE
🚀 Add ability to off debug symbols

### DIFF
--- a/Docs/Cache.md
+++ b/Docs/Cache.md
@@ -5,16 +5,17 @@
 OVERVIEW: Convert pods to prebuilt dependencies.
 
 OPTIONS:
-  -a, --arch <arch>         Build architectures. (default: sim x86_64, ios arm64)
-  -c, --config <config>     Build configuration. (default: Debug)
-  -s, --sdk <sdk>           Build sdks: sim/ios or both. (default: sim)
-  --bitcode                 Add bitcode for archive builds.
-  -k, --keep-sources        Keep Pods group in project.
-  -e, --exclude <exclude>   Exclude pods from cache.
-  --include <include>       Include local pods.
-  --focus <focus>           Keep selected local pods and cache others.
-  --ignore-checksums        Ignore already cached pods checksums.
-  --graph                   Add parents of changed pods to build process.
+  -s, --sdk <sdk>         Build sdks: sim/ios or both. (default: sim)
+  -a, --arch <arch>       Build architectures. (default: sim x86_64, ios arm64)
+  -c, --config <config>   Build configuration. (default: Debug)
+  --bitcode               Add bitcode for archive builds.
+  -k, --keep-sources      Keep Pods group in project.
+  -e, --exclude <exclude> Exclude pods from cache.
+  --include <include>     Include local pods.
+  --focus <focus>         Keep selected local pods and cache others.
+  --graph/--no-graph      Build changed pods parents. (default: true)
+  --ignore-checksums      Ignore already cached pods checksums.
+  --off-debug-symbols     (Experimental) Build without debug symbols.
 
   --bell/--no-bell          Play bell sound on finish. (default: true)
   --hide-metrics            Hide metrics.
@@ -137,4 +138,16 @@ Please, report in the discussions section if you have some troubles building in 
 
 ```bash
 rugby --graph
+```
+
+## Disable debug symbols generation
+
+With this flag, Rugby will off debug symbols generation and strip all already generated symbols.
+
+It can be valuable in enormous projects. Usually, we don't need to debug binaries. It will be better to focus on a group of pods developing currently.
+In some cases, it speeds up debugger attachment by 16x (147s vs 9s) in my work project.
+Also, it slightly speeds up app launch time.
+
+```bash
+rugby --off-debug-symbols
 ```

--- a/Docs/Plans.md
+++ b/Docs/Plans.md
@@ -17,6 +17,7 @@ OPTIONS:
   --focus <focus>         Keep selected local pods and cache others.
   --graph/--no-graph      Build changed pods parents. (default: true)
   --ignore-checksums      Ignore already cached pods checksums.
+  --off-debug-symbols     (Experimental) Build without debug symbols.
 
   --bell/--no-bell        Play bell sound on finish. (default: true)
   --hide-metrics          Hide metrics.
@@ -70,6 +71,7 @@ rugby example
     focus: []
     hideMetrics: false
     ignoreChecksums: false
+    offDebugSymbols: false
     verbose: false
     quiet: false
 

--- a/Sources/Rugby/Commands/Cache/Command/CacheHeader.swift
+++ b/Sources/Rugby/Commands/Cache/Command/CacheHeader.swift
@@ -21,7 +21,8 @@ struct Cache: ParsableCommand {
     @Option(parsing: .upToNextOption, help: "Include local pods.") var include: [String] = []
     @Option(parsing: .upToNextOption, help: "Keep selected local pods and cache others.") var focus: [String] = []
     @Flag(inversion: .prefixedNo, help: "Build changed pods parents.") var graph = true
-    @Flag(help: "Ignore already cached pods checksums.\n") var ignoreChecksums = false
+    @Flag(help: "Ignore already cached pods checksums.") var ignoreChecksums = false
+    @Flag(help: "(Experimental) Build without debug symbols.\n") var offDebugSymbols = false
 
     @OptionGroup var flags: CommonFlags
 

--- a/Sources/Rugby/Commands/Cache/Other/Build/XCARGSProvider.swift
+++ b/Sources/Rugby/Commands/Cache/Other/Build/XCARGSProvider.swift
@@ -9,11 +9,21 @@
 struct XCARGSProvider {
     private let base = ["COMPILER_INDEX_STORE_ENABLE=NO",
                         "SWIFT_COMPILATION_MODE=wholemodule"]
+    private let disableDebugSymbolsGeneration = "GCC_GENERATE_DEBUGGING_SYMBOLS=NO"
+    private let stripDebugSymbols = [
+        "STRIP_INSTALLED_PRODUCT=YES",
+        "COPY_PHASE_STRIP=YES",
+        "STRIP_STYLE=all"
+    ]
     private let useBitcode = "BITCODE_GENERATION_MODE=bitcode"
 
-    func xcargs(bitcode: Bool) -> [String] {
+    func xcargs(bitcode: Bool, withoutDebugSymbols: Bool) -> [String] {
         var xcargs = base
         if bitcode { xcargs.append(useBitcode) }
+        if withoutDebugSymbols {
+            xcargs.append(disableDebugSymbolsGeneration)
+            xcargs.append(contentsOf: stripDebugSymbols)
+        }
         return xcargs
     }
 }

--- a/Sources/Rugby/Commands/Cache/Steps/CacheBuildStep.swift
+++ b/Sources/Rugby/Commands/Cache/Steps/CacheBuildStep.swift
@@ -43,7 +43,7 @@ struct CacheBuildStep: Step {
             return done()
         }
 
-        let xcargs = xcargsProvider.xcargs(bitcode: command.bitcode)
+        let xcargs = xcargsProvider.xcargs(bitcode: command.bitcode, withoutDebugSymbols: command.offDebugSymbols)
         for (sdk, arch) in zip(input.buildInfo.sdk, input.buildInfo.arch) {
             try progress.spinner("Building \("\(sdk)-\(arch)".yellow)") {
                 do {

--- a/Sources/Rugby/Commands/Cache/Steps/Prepare/Substeps/FindBuildPods.swift
+++ b/Sources/Rugby/Commands/Cache/Steps/Prepare/Substeps/FindBuildPods.swift
@@ -28,7 +28,7 @@ extension CacheSubstepFactory {
 
             // Find checksums difference from cache file
             var buildPods: Set<String> = []
-            let xcargs = xcargsProvider.xcargs(bitcode: command.bitcode)
+            let xcargs = xcargsProvider.xcargs(bitcode: command.bitcode, withoutDebugSymbols: command.offDebugSymbols)
             let swiftVersion = SwiftVersionProvider().swiftVersion()
             var buildSDKs: [SDK] = []
             var buildARCHs: [String] = []

--- a/Sources/Rugby/Commands/Plan/Command/PlanHeader.swift
+++ b/Sources/Rugby/Commands/Plan/Command/PlanHeader.swift
@@ -50,6 +50,7 @@ struct Plans: ParsableCommand {
         cache.focus = cacheOptions.focus
         cache.graph = cacheOptions.graph
         cache.flags = cacheOptions.flags
+        cache.offDebugSymbols = cacheOptions.offDebugSymbols
         try cache.wrappedRun()
     }
 }

--- a/Sources/Rugby/Commands/Plan/Parser/DecodableModels/CacheDecodable.swift
+++ b/Sources/Rugby/Commands/Plan/Parser/DecodableModels/CacheDecodable.swift
@@ -17,6 +17,7 @@ struct CacheDecodable: Decodable {
     let include: [String]?
     let focus: [String]?
     let graph: Bool?
+    let offDebugSymbols: Bool?
     let bell: Bool?
     let hideMetrics: Bool?
     @BoolableIntDecodable var verbose: Int?
@@ -35,6 +36,7 @@ extension Cache {
         self.include = decodable.include ?? []
         self.focus = decodable.focus ?? []
         self.graph = decodable.graph ?? true
+        self.offDebugSymbols = decodable.offDebugSymbols ?? false
 
         self.flags = .init()
         self.flags.bell = decodable.bell ?? true

--- a/Sources/Rugby/Commands/Plan/Subcommands/PlansExample.swift
+++ b/Sources/Rugby/Commands/Plan/Subcommands/PlansExample.swift
@@ -67,6 +67,7 @@ struct PlansExample: ParsableCommand {
             #focus: []
             #hideMetrics: false
             #ignoreChecksums: false
+            #offDebugSymbols: false
             #verbose: false
             quiet: true
 


### PR DESCRIPTION
### Description

I added a new experimental flag `--off-debug-symbols`.
With this flag, 🏈 Rugby will off debug symbols generation and strip all already generated symbols.

It can be valuable in enormous projects.
Usually, we don't need to debug binaries. It will be better to focus on a group of pods developing currently.
In some cases, it speeds up debugger attachment by 16x (147s vs 9s) in my work project.
Also, it slightly speeds up app launch time.

I've collected some metrics in my work project:
```bash
Metric             | Speed up
-------------------------------------
Build Time         | 6%
Breakpoint Await   | x16
Launch Time        | 23%
build/ folder size | 21%
```

### References
None

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

❤️ Thanks for contributing to the 🏈 Rugby!
