### PR TITLE
🔭 Rollback

### DIFF
--- a/.github/scripts/spell_checker_whitelist.yml
+++ b/.github/scripts/spell_checker_whitelist.yml
@@ -55,3 +55,4 @@ whiteList:
   - khorkov
   - proj
   - deintegrate
+  - rhs

--- a/.github/scripts/spell_checker_whitelist.yml
+++ b/.github/scripts/spell_checker_whitelist.yml
@@ -54,3 +54,4 @@ whiteList:
   - img
   - khorkov
   - proj
+  - deintegrate

--- a/Docs/README.md
+++ b/Docs/README.md
@@ -15,6 +15,7 @@ SUBCOMMANDS:
                        Call it after each pod install.
   focus              • Keep only selected targets and all their dependencies.
   drop               • Remove any targets by RegEx.
+  rollback           • (Beta, Hidden) Deintegrate Rugby from your project.
   log                • Print last command log verbosely.
   doctor             • Show troubleshooting suggestions.
   clean              • Remove cache except plans.yml and logs.

--- a/Sources/Rugby/Commands/Cache/Command/CacheHeader.swift
+++ b/Sources/Rugby/Commands/Cache/Command/CacheHeader.swift
@@ -22,7 +22,7 @@ struct Cache: ParsableCommand {
     @Option(parsing: .upToNextOption, help: "Keep selected local pods and cache others.") var focus: [String] = []
     @Flag(inversion: .prefixedNo, help: "Build changed pods parents.") var graph = true
     @Flag(help: "Ignore already cached pods checksums.") var ignoreChecksums = false
-    @Flag(help: "(Experimental) Build without debug symbols.\n") var offDebugSymbols = false
+    @Flag(help: "\("(Beta)".yellow) Build without debug symbols.\n") var offDebugSymbols = false
 
     @OptionGroup var flags: CommonFlags
 

--- a/Sources/Rugby/Commands/Cache/Other/Backup/BackupManager.swift
+++ b/Sources/Rugby/Commands/Cache/Other/Backup/BackupManager.swift
@@ -1,0 +1,101 @@
+//
+//  BackupManager.swift
+//  Rugby
+//
+//  Created by Vyacheslav Khorkov on 16.06.2022.
+//  Copyright © 2021 Vyacheslav Khorkov. All rights reserved.
+//
+
+import Files
+import Foundation
+
+struct BackupManager {
+    enum Error: LocalizedError {
+        case missingBackup
+
+        var errorDescription: String? {
+            switch self {
+            case .missingBackup:
+                return "Can't find backup."
+            }
+        }
+    }
+
+    private let progress: Printer
+
+    init(progress: Printer) {
+        self.progress = progress
+    }
+}
+
+// MARK: - Backup
+
+extension BackupManager {
+    func backup(path: String) throws {
+        let project = try ProjectProvider.shared.readProject(path)
+        guard !project.pbxproj.main.contains(buildSettingsKey: .rugbyPatched) else {
+            return /* Backup already must be */
+        }
+
+        let backupFolder = try Folder.current.createSubfolderIfNeeded(at: .backupFolder)
+        let filesForBackup = try prepareForBackup(path: path, backupFolder: backupFolder)
+        try filesForBackup.forEach { filePath in
+            try moveFolder(from: filePath, toBackup: backupFolder)
+            progress.print("Backup ".yellow + filePath)
+        }
+    }
+
+    private func prepareForBackup(path: String, backupFolder: Folder) throws -> [String] {
+        if path == .podsProject {
+            try deleteLastBackup(relativePath: .podsFolder, backupFolder: backupFolder)
+            return [.podsProject, .podsTargetSupportFiles]
+        } else {
+            try deleteLastBackup(relativePath: path, backupFolder: backupFolder)
+            return [path]
+        }
+    }
+
+    private func deleteLastBackup(relativePath: String, backupFolder: Folder) throws {
+        guard let rootSubfolderName = relativePath.components(separatedBy: "/").first else { return }
+        backupFolder.deleteSubfolderIfExists(at: rootSubfolderName)
+    }
+
+    private func moveFolder(from path: String, toBackup backupFolder: Folder) throws {
+        guard let rootSubfolderName = path.components(separatedBy: "/").first else { return }
+        let targetFolder = try backupFolder.createSubfolderIfNeeded(at: rootSubfolderName)
+        try Folder.current.subfolder(at: path).copy(to: targetFolder)
+    }
+}
+
+// MARK: - Rollback
+
+extension BackupManager {
+    func rollback() throws {
+        let map = try prepareRollback()
+        try map.forEach { backupFile, targetFolder in
+            targetFolder.deleteFileIfExists(at: backupFile.name)
+            try backupFile.copy(to: targetFolder)
+
+            let backupFolder = try Folder.current.subfolder(at: .backupFolder)
+            let backupPath = backupFile.path(relativeTo: backupFolder)
+            let targetFolderPath = targetFolder.path(relativeTo: Folder.current)
+            progress.print("Restore ".yellow + backupPath + " ➞ ".yellow + targetFolderPath)
+        }
+    }
+
+    private func prepareRollback() throws -> [(backupFile: File, targetFolder: Folder)] {
+        guard
+            let backupFolder = try? Folder.current.subfolder(at: .backupFolder),
+            !backupFolder.isEmpty()
+        else {
+            throw Error.missingBackup
+        }
+
+        return backupFolder.files.recursive.compactMap {
+            guard let parent = $0.parent else { return nil }
+            let parentRelativePath = parent.path(relativeTo: backupFolder)
+            guard let targetFolder = try? Folder.current.subfolder(at: parentRelativePath) else { return nil }
+            return ($0, targetFolder)
+        }
+    }
+}

--- a/Sources/Rugby/Commands/Cache/Steps/Prepare/CachePrepareStep.swift
+++ b/Sources/Rugby/Commands/Cache/Steps/Prepare/CachePrepareStep.swift
@@ -20,6 +20,7 @@ struct CachePrepareStep: Step {
     let verbose: Int
     let isLast: Bool
     let progress: Printer
+    let backupManager: BackupManager
 
     private let command: Cache
     private let metrics: Metrics
@@ -30,6 +31,7 @@ struct CachePrepareStep: Step {
         self.verbose = command.flags.verbose
         self.isLast = isLast
         self.progress = RugbyPrinter(title: "Prepare", logFile: logFile, verbose: verbose, quiet: command.flags.quiet)
+        self.backupManager = BackupManager(progress: progress)
     }
 }
 
@@ -50,6 +52,7 @@ extension CachePrepareStep {
         let projectPatched = project.pbxproj.main.contains(buildSettingsKey: .rugbyPatched)
         if projectPatched { throw CacheError.projectAlreadyPatched }
 
+        try backupManager.backup(path: .podsProject)
         let factory = CacheSubstepFactory(progress: progress, command: command, metrics: metrics)
         let (selectedPods, excludedPods) = try factory.selectPods(project)
         let (buildInfo, swiftVersion) = try factory.findBuildPods(selectedPods)

--- a/Sources/Rugby/Commands/Clean/Clean.swift
+++ b/Sources/Rugby/Commands/Clean/Clean.swift
@@ -32,13 +32,13 @@ struct CleanStep: Step {
     }
 
     func run(_ input: Void) {
-        if (try? Folder.current.subfolder(at: .buildFolder).delete()) != nil {
+        if Folder.current.deleteSubfolderIfExists(at: .backupFolder) {
             progress.print("Removed \(String.buildFolder)".yellow)
         }
 
         let filesForDelete: [String] = [.cacheFile]
         filesForDelete.forEach {
-            if (try? Folder.current.file(at: $0).delete()) != nil {
+            if Folder.current.deleteFileIfExists(at: $0) {
                 progress.print("Removed \($0)".yellow)
             }
         }

--- a/Sources/Rugby/Commands/Drop/Steps/DropRemoveStep.swift
+++ b/Sources/Rugby/Commands/Drop/Steps/DropRemoveStep.swift
@@ -80,7 +80,6 @@ struct DropRemoveStep: Step {
         progress.print(removedTargets, text: "Removed targets", deletion: true)
 
         try progress.spinner("Save project") {
-            project.pbxproj.main.set(buildSettingsKey: .rugbyPatched, value: String.yes)
             try project.write(pathString: input.project, override: true)
         }
 

--- a/Sources/Rugby/Commands/Rollback/Rollback.swift
+++ b/Sources/Rugby/Commands/Rollback/Rollback.swift
@@ -27,9 +27,15 @@ struct Rollback: ParsableCommand, Command {
 
 extension Rollback {
     mutating func run(logFile: File) throws -> Metrics? {
-        let progress = RugbyPrinter(title: "Rollback", logFile: logFile, verbose: verbose, quiet: quiet)
+        let progress = RugbyPrinter(title: "Rollback", logFile: logFile, verbose: verbose + 1, quiet: quiet)
         let backupManager = BackupManager(progress: progress)
-        try backupManager.rollback()
+        if verbose.bool {
+            try backupManager.rollback()
+        } else {
+            try progress.spinner("Rollback") {
+                try backupManager.rollback()
+            }
+        }
         progress.done()
         return nil
     }

--- a/Sources/Rugby/Commands/Rollback/Rollback.swift
+++ b/Sources/Rugby/Commands/Rollback/Rollback.swift
@@ -1,0 +1,36 @@
+//
+//  Rollback.swift
+//  Rugby
+//
+//  Created by Vyacheslav Khorkov on 16.06.2022.
+//  Copyright © 2021 Vyacheslav Khorkov. All rights reserved.
+//
+
+import ArgumentParser
+import Files
+
+struct Rollback: ParsableCommand, Command {
+    @Flag(name: .shortAndLong, help: "Print more information.") var verbose: Int
+    @Flag(name: .shortAndLong, help: "Print nothing.") var quiet = false
+
+    static var configuration = CommandConfiguration(
+        abstract: "• \("(Beta)".yellow) Deintegrate Rugby from your project.",
+        shouldDisplay: false
+    )
+
+    mutating func run() throws {
+        try WrappedError.wrap(playBell: false) {
+            try wrappedRun()
+        }
+    }
+}
+
+extension Rollback {
+    mutating func run(logFile: File) throws -> Metrics? {
+        let progress = RugbyPrinter(title: "Rollback", logFile: logFile, verbose: verbose, quiet: quiet)
+        let backupManager = BackupManager(progress: progress)
+        try backupManager.rollback()
+        progress.done()
+        return nil
+    }
+}

--- a/Sources/Rugby/Common/Environment/String+Env.swift
+++ b/Sources/Rugby/Common/Environment/String+Env.swift
@@ -41,6 +41,7 @@ extension String {
     // MARK: - Xcode Project Variables
 
     static let rugbyPatched = "RUGBY_PATCHED"
+    static let rugbyHasBackup = "RUGBY_HAS_BACKUP"
     static let yes: Any = "YES"
 
     // MARK: - Cache command

--- a/Sources/Rugby/Common/Environment/String+Env.swift
+++ b/Sources/Rugby/Common/Environment/String+Env.swift
@@ -15,18 +15,28 @@ extension String {
 
     // MARK: - Common
 
+    static let podsFolder = "Pods"
     static let podsGroup = "Pods"
     static let developmentPodsGroup = "Development Pods"
     static let supportFolder = ".rugby"
     static let log = supportFolder + "/rugby.log"
     static let plans = supportFolder + "/plans.yml"
     static let lockfile = "Podfile.lock"
-    static let podsProject = "Pods/Pods.xcodeproj"
-    static let podsTargetSupportFiles = "Pods/Target Support Files"
+
+    static let podsProjectName = "Pods.xcodeproj"
+    static let podsProject = podsFolder + "/" + podsProjectName
+    static let podsTargetSupportFilesName = "Target Support Files"
+    static let podsTargetSupportFiles = podsFolder + "/" + podsTargetSupportFilesName
 
     // MARK: - History
 
     static let history = supportFolder + "/history"
+
+    // MARK: - Backup
+
+    static let backupFolder = supportFolder + "/backup"
+    static let backupPodsProject = backupFolder + "/" + podsProjectName
+    static let backupPodsTargetSupportFiles = backupFolder + "/" + podsTargetSupportFilesName
 
     // MARK: - Xcode Project Variables
 

--- a/Sources/Rugby/Common/Utils/FileManager.swift
+++ b/Sources/Rugby/Common/Utils/FileManager.swift
@@ -14,6 +14,28 @@ extension Folder {
     func size() -> Int? {
         FileManager.default.directorySize(url)
     }
+
+    func isSubfolderExists(at path: String) -> Bool {
+        (try? subfolder(at: path)) != nil
+    }
+
+    func isFileExists(at path: String) -> Bool {
+        (try? file(at: path)) != nil
+    }
+
+    @discardableResult
+    func deleteSubfolderIfExists(at path: String) -> Bool {
+        guard isSubfolderExists(at: path) else { return false }
+        try? subfolder(at: path).delete()
+        return true
+    }
+
+    @discardableResult
+    func deleteFileIfExists(at path: String) -> Bool {
+        guard isFileExists(at: path) else { return false }
+        try? file(at: path).delete()
+        return true
+    }
 }
 
 private extension FileManager {

--- a/Sources/Rugby/Common/XcodeProj/Scheme/XcodeProj+RemoveSchemes.swift
+++ b/Sources/Rugby/Common/XcodeProj/Scheme/XcodeProj+RemoveSchemes.swift
@@ -55,15 +55,15 @@ extension XcodeProj {
         // Anyway remove schemes from project
         defer { sharedData?.schemes.removeAll { schemesForRemove.contains($0.name) } }
 
+        let sharedSchemes = try? Folder(path: projectPath + "/xcshareddata/xcschemes")
         schemesForRemove.forEach {
-            let sharedSchemes = try? Folder(path: projectPath + "/xcshareddata/xcschemes")
-            try? sharedSchemes?.file(at: $0 + ".xcscheme").delete()
+            sharedSchemes?.deleteFileIfExists(at: $0 + ".xcscheme")
         }
 
         let username = try shell("echo $USER").trimmingCharacters(in: .whitespacesAndNewlines)
+        let userSchemesFolder = try? Folder(path: projectPath + "/xcuserdata/\(username).xcuserdatad/xcschemes")
         schemesForRemove.forEach {
-            let userSchemesFolder = try? Folder(path: projectPath + "/xcuserdata/\(username).xcuserdatad/xcschemes")
-            try? userSchemesFolder?.file(at: $0 + ".xcscheme").delete()
+            userSchemesFolder?.deleteFileIfExists(at: $0 + ".xcscheme")
         }
     }
 }

--- a/Sources/Rugby/main.swift
+++ b/Sources/Rugby/main.swift
@@ -13,6 +13,7 @@ struct Rugby: ParsableCommand {
             Cache.self,
             Focus.self,
             Drop.self,
+            Rollback.self,
             Log.self,
             Doctor.self,
             Clean.self

--- a/TestProject/Fastlane/Fastfile
+++ b/TestProject/Fastlane/Fastfile
@@ -1,6 +1,7 @@
 #!/bin/ruby
 
 import "./Xcode"
+import "./Utils"
 import "Tests/Commands/Cache"
 import "Tests/Commands/Drop"
 import "Tests/Commands/Focus"

--- a/TestProject/Fastlane/Tests/Commands/Cache
+++ b/TestProject/Fastlane/Tests/Commands/Cache
@@ -24,6 +24,6 @@ lane :cache_different_config do
     sh "cd .. && rugby -c \"Staging With Spaces\" --no-bell -q"
     build(configuration: "Staging With Spaces")
 
-    sh "cd .. && rugby rollback"
+    sh "cd .. && rugby rollback -q"
     ensure_git_clean
 end

--- a/TestProject/Fastlane/Tests/Commands/Cache
+++ b/TestProject/Fastlane/Tests/Commands/Cache
@@ -5,16 +5,25 @@ lane :cache_both do
     sh "cd .. && rugby -s ios sim --no-bell -q"
     run_unit_tests
     build_ios
+
+    sh "cd .. && rugby rollback"
+    ensure_git_clean
 end
 
 lane :cache_exclude do
     cocoapods(try_repo_update_on_error: true)
     sh "cd .. && rugby -e Alamofire --no-bell -q"
     run_unit_tests
+
+    sh "cd .. && rugby rollback"
+    ensure_git_clean
 end
 
 lane :cache_different_config do
     cocoapods(try_repo_update_on_error: true)
     sh "cd .. && rugby -c \"Staging With Spaces\" --no-bell -q"
     build(configuration: "Staging With Spaces")
+
+    sh "cd .. && rugby rollback"
+    ensure_git_clean
 end

--- a/TestProject/Fastlane/Tests/Commands/Drop
+++ b/TestProject/Fastlane/Tests/Commands/Drop
@@ -23,6 +23,6 @@ private_lane :drop_basic_usage do
     sh "cd .. && rugby drop \"TestProject\" -p TestProject/TestProject.xcodeproj --no-bell -q"
     check_that_scemes_empty
 
-    sh "cd .. && rugby rollback"
+    sh "cd .. && rugby rollback -q"
     ensure_git_clean
 end

--- a/TestProject/Fastlane/Tests/Commands/Drop
+++ b/TestProject/Fastlane/Tests/Commands/Drop
@@ -22,4 +22,7 @@ private_lane :drop_basic_usage do
     
     sh "cd .. && rugby drop \"TestProject\" -p TestProject/TestProject.xcodeproj --no-bell -q"
     check_that_scemes_empty
+
+    sh "cd .. && rugby rollback"
+    ensure_git_clean
 end

--- a/TestProject/Fastlane/Tests/Commands/Focus
+++ b/TestProject/Fastlane/Tests/Commands/Focus
@@ -13,6 +13,6 @@ private_lane :focus_basic_usage do
     end
     build
 
-    sh "cd .. && rugby rollback"
+    sh "cd .. && rugby rollback -q"
     ensure_git_clean
 end

--- a/TestProject/Fastlane/Tests/Commands/Focus
+++ b/TestProject/Fastlane/Tests/Commands/Focus
@@ -12,4 +12,7 @@ private_lane :focus_basic_usage do
         sh "rugby focus \"TestProject\" -p TestProject/TestProject.xcodeproj --no-bell -q"
     end
     build
+
+    sh "cd .. && rugby rollback"
+    ensure_git_clean
 end

--- a/TestProject/Fastlane/Tests/Commands/Plans
+++ b/TestProject/Fastlane/Tests/Commands/Plans
@@ -12,6 +12,6 @@ private_lane :plans_basic_usage do
     end
     build
 
-    sh "cd .. && rugby rollback"
+    sh "cd .. && rugby rollback -q"
     ensure_git_clean
 end

--- a/TestProject/Fastlane/Tests/Commands/Plans
+++ b/TestProject/Fastlane/Tests/Commands/Plans
@@ -11,4 +11,7 @@ private_lane :plans_basic_usage do
         sh "rugby --plan usual --no-bell -q"
     end
     build
+
+    sh "cd .. && rugby rollback"
+    ensure_git_clean
 end

--- a/TestProject/Fastlane/Utils
+++ b/TestProject/Fastlane/Utils
@@ -1,0 +1,10 @@
+#!/bin/ruby
+
+lane :ensure_git_clean do |options|
+    git_status = %x[git status --porcelain --untracked-files=no]
+    if git_status.empty?
+        puts("Working directory is clean")
+    elsif
+        abort("Error: Working directory is not clean!\n" + git_status)
+    end
+end


### PR DESCRIPTION
### Description
After this pull request we can discard all 🏈 Rugby changes instantly without calling `pod install`.

### References
Closes #174

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

❤️ Thanks for contributing to the 🏈 Rugby!
