### PR TITLE
🔭 Improve directory detection: Big performance improvement for certain setups

### DIFF
--- a/Sources/Rugby/Commands/Cache/Other/Checksums/CombinedChecksum.swift
+++ b/Sources/Rugby/Commands/Cache/Other/Checksums/CombinedChecksum.swift
@@ -45,7 +45,7 @@ extension LocalPod: CombinedChecksum {
         switch path {
         case ".":
             subpath = name
-        case let filePath where filePath.isFile:
+        case let filePath where !filePath.isDirectory:
             subpath = filePath.dropFileName()
         default:
             subpath = path

--- a/Sources/Rugby/Common/Extensions/String+File.swift
+++ b/Sources/Rugby/Common/Extensions/String+File.swift
@@ -25,8 +25,8 @@ extension String {
     }
 
     /// Check if string contains dot
-    var isFile: Bool {
-        contains(".")
+    var isDirectory: Bool {
+        (try? URL(fileURLWithPath: self).resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
     }
 
     var shellFriendly: String { replacingOccurrences(of: " ", with: "\\ ") }


### PR DESCRIPTION
### Description
Current directory detection is looking for `.` (File extension?). This is problematic for directories that contain a `.`, or relative paths `../`. This change uses URL apis check if a file is a directory.
On a semi-large react-native project (lots of relative `../node_modules` imports, this speeds up the run of rugby dramatically), it was incorrectly checksumming the parent directory, which in many cases was the huge `node_modules` directory. I'm not entirely sure why, but it was also causing the pods to get checksummed twice (once in prepare and again in build phase).

Before:
```
[3m] Prepare ✓
[3m 36s] Build ✓
[1s] Integration ✓
[1s] Clean up ✓
[6m 37s] Cached 139/166 pods.
[!] Project size ↓83%
[!] Indexing files count ↓96%
[!] Targets count ↓83%
[6m 37s] Let's roll 🏈
66.36s user 129.83s system 49% cpu 6:38.84 total
```

After:
```
[4s] Prepare ✓
[20s] Build ✓
[1s] Integration ✓
[1s] Clean up ✓
[25s] Cached 139/166 pods.
[!] Project size ↓83%
[!] Indexing files count ↓96%
[!] Targets count ↓83%
[25s] Let's roll 🏈
9.41s user 1.69s system 38% cpu 28.475 total
```

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate (should be covered by TestProject)
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

❤️ Thanks for contributing to the 🏈 Rugby!
