### PR TITLE
Add --non-interactive flag which limits spinner output for non-interactive terminals (Ex: CI)

### DIFF
--- a/Sources/Rugby/Commands/Cache/Command/CacheRun.swift
+++ b/Sources/Rugby/Commands/Cache/Command/CacheRun.swift
@@ -10,6 +10,7 @@ import Files
 
 extension Cache: Command {
     var quiet: Bool { flags.quiet }
+    var nonInteractive: Bool { flags.nonInteractive }
 
     mutating func run(logFile: File) throws -> Metrics? {
         if !arch.isEmpty, sdk.count != arch.count { throw CacheError.incorrectArchCount }

--- a/Sources/Rugby/Commands/Cache/Steps/CacheBuildStep.swift
+++ b/Sources/Rugby/Commands/Cache/Steps/CacheBuildStep.swift
@@ -34,7 +34,11 @@ struct CacheBuildStep: Step {
         self.command = command
         self.verbose = command.flags.verbose
         self.isLast = isLast
-        self.progress = RugbyPrinter(title: "Build", logFile: logFile, verbose: verbose, quiet: command.quiet)
+        self.progress = RugbyPrinter(title: "Build",
+                                     logFile: logFile,
+                                     verbose: verbose,
+                                     quiet: command.quiet,
+                                     nonInteractive: command.nonInteractive)
         self.checksumsProvider = ChecksumsProvider(shouldChecksumContent: command.experimentalChecksumContent)
     }
 

--- a/Sources/Rugby/Commands/Cache/Steps/CacheCleanupStep.swift
+++ b/Sources/Rugby/Commands/Cache/Steps/CacheCleanupStep.swift
@@ -28,7 +28,11 @@ struct CacheCleanupStep: Step {
         self.metrics = metrics
         self.verbose = command.flags.verbose
         self.isLast = isLast
-        self.progress = RugbyPrinter(title: "Clean up", logFile: logFile, verbose: verbose, quiet: command.flags.quiet)
+        self.progress = RugbyPrinter(title: "Clean up",
+                                     logFile: logFile,
+                                     verbose: verbose,
+                                     quiet: command.flags.quiet,
+                                     nonInteractive: command.flags.nonInteractive)
     }
 
     func run(_ input: Input) throws {

--- a/Sources/Rugby/Commands/Cache/Steps/CacheIntegrateStep.swift
+++ b/Sources/Rugby/Commands/Cache/Steps/CacheIntegrateStep.swift
@@ -22,7 +22,8 @@ struct CacheIntegrateStep: Step {
         self.progress = RugbyPrinter(title: "Integration",
                                      logFile: logFile,
                                      verbose: verbose,
-                                     quiet: command.flags.quiet)
+                                     quiet: command.flags.quiet,
+                                     nonInteractive: command.flags.nonInteractive)
     }
 
     func run(_ targets: Set<String>) throws {

--- a/Sources/Rugby/Commands/Cache/Steps/Prepare/CachePrepareStep.swift
+++ b/Sources/Rugby/Commands/Cache/Steps/Prepare/CachePrepareStep.swift
@@ -30,7 +30,11 @@ struct CachePrepareStep: Step {
         self.metrics = metrics
         self.verbose = command.flags.verbose
         self.isLast = isLast
-        self.progress = RugbyPrinter(title: "Prepare", logFile: logFile, verbose: verbose, quiet: command.flags.quiet)
+        self.progress = RugbyPrinter(title: "Prepare",
+                                     logFile: logFile,
+                                     verbose: verbose,
+                                     quiet: command.flags.quiet,
+                                     nonInteractive: command.flags.nonInteractive)
         self.backupManager = BackupManager(progress: progress)
     }
 }

--- a/Sources/Rugby/Commands/Clean/Clean.swift
+++ b/Sources/Rugby/Commands/Clean/Clean.swift
@@ -28,7 +28,7 @@ struct CleanStep: Step {
     let progress: Printer
 
     init() {
-        self.progress = RugbyPrinter(title: "Clean", verbose: .verbose, quiet: false)
+        self.progress = RugbyPrinter(title: "Clean", verbose: .verbose, quiet: false, nonInteractive: false)
     }
 
     func run(_ input: Void) {

--- a/Sources/Rugby/Commands/Drop/Command/DropRun.swift
+++ b/Sources/Rugby/Commands/Drop/Command/DropRun.swift
@@ -10,6 +10,7 @@ import Files
 
 extension Drop: Command {
     var quiet: Bool { flags.quiet }
+    var nonInteractive: Bool { flags.nonInteractive }
 
     mutating func run(logFile: File) throws -> Metrics? {
         if testFlight, flags.verbose == 0 { flags.verbose = 1 }

--- a/Sources/Rugby/Commands/Drop/Steps/DropPrepareStep.swift
+++ b/Sources/Rugby/Commands/Drop/Steps/DropPrepareStep.swift
@@ -21,7 +21,11 @@ struct DropPrepareStep: Step {
         self.metrics = metrics
         self.verbose = command.flags.verbose
         self.isLast = isLast
-        self.progress = RugbyPrinter(title: "Prepare", logFile: logFile, verbose: verbose, quiet: command.flags.quiet)
+        self.progress = RugbyPrinter(title: "Prepare",
+                                     logFile: logFile,
+                                     verbose: verbose,
+                                     quiet: command.flags.quiet,
+                                     nonInteractive: command.flags.nonInteractive)
     }
 
     func run(_ input: Void) throws -> (foundTargets: Set<String>, products: Set<String>) {

--- a/Sources/Rugby/Commands/Drop/Steps/DropRemoveStep.swift
+++ b/Sources/Rugby/Commands/Drop/Steps/DropRemoveStep.swift
@@ -33,7 +33,8 @@ struct DropRemoveStep: Step {
         self.progress = RugbyPrinter(title: "Drop",
                                      logFile: logFile,
                                      verbose: verbose,
-                                     quiet: command.quiet)
+                                     quiet: command.quiet,
+                                     nonInteractive: command.nonInteractive)
         self.backupManager = BackupManager(progress: progress)
     }
 

--- a/Sources/Rugby/Commands/Focus/Command/FocusRun.swift
+++ b/Sources/Rugby/Commands/Focus/Command/FocusRun.swift
@@ -10,6 +10,7 @@ import Files
 
 extension Focus: Command {
     var quiet: Bool { flags.quiet }
+    var nonInteractive: Bool { flags.nonInteractive }
 
     mutating func run(logFile: File) throws -> Metrics? {
         if testFlight, flags.verbose == 0 { flags.verbose = 1 }

--- a/Sources/Rugby/Commands/Focus/Steps/FocusPrepareStep.swift
+++ b/Sources/Rugby/Commands/Focus/Steps/FocusPrepareStep.swift
@@ -22,7 +22,11 @@ struct FocusPrepareStep: Step {
         self.metrics = metrics
         self.verbose = command.flags.verbose
         self.isLast = isLast
-        self.progress = RugbyPrinter(title: "Focus", logFile: logFile, verbose: verbose, quiet: command.flags.quiet)
+        self.progress = RugbyPrinter(title: "Focus",
+                                     logFile: logFile,
+                                     verbose: verbose,
+                                     quiet: command.flags.quiet,
+                                     nonInteractive: command.flags.nonInteractive)
     }
 
     func run(_ input: Void) throws -> (foundTargets: Set<String>, products: Set<String>) {

--- a/Sources/Rugby/Commands/Plan/Command/PlanRun.swift
+++ b/Sources/Rugby/Commands/Plan/Command/PlanRun.swift
@@ -95,18 +95,30 @@ extension Plans {
     private func outputProjectMetrics(_ metrics: [Metrics], logFile: File) {
         guard let combinedMetrics = metrics.combine() else { return }
         let projectHeader = "[!] " + combinedMetrics.project + ":"
-        RugbyPrinter(logFile: logFile, verbose: .verbose, quiet: cacheOptions.flags.quiet).print(projectHeader.green)
+        let printer = RugbyPrinter(logFile: logFile,
+                                   verbose: .verbose,
+                                   quiet: cacheOptions.flags.quiet,
+                                   nonInteractive: cacheOptions.flags.nonInteractive)
+        printer.print(projectHeader.green)
         outputMore(combinedMetrics, logFile: logFile, quiet: cacheOptions.flags.quiet)
         printEmptyLine(logFile: logFile)
     }
 
     private func printEmptyLine(logFile: File) {
-        RugbyPrinter(logFile: logFile, verbose: .verbose, quiet: cacheOptions.flags.quiet).print(.separator)
+        let printer = RugbyPrinter(logFile: logFile,
+                                   verbose: .verbose,
+                                   quiet: cacheOptions.flags.quiet,
+                                   nonInteractive: cacheOptions.flags.nonInteractive)
+        printer.print(.separator)
     }
 
     private func printSelectedPlan(plan: String, logFile: File) {
-        RugbyPrinter(title: "Plans ✈️ ", logFile: logFile, verbose: .verbose, quiet: cacheOptions.flags.quiet)
-            .print("\(plan.yellow)")
+        let printer = RugbyPrinter(title: "Plans ✈️ ",
+                                   logFile: logFile,
+                                   verbose: .verbose,
+                                   quiet: cacheOptions.flags.quiet,
+                                   nonInteractive: cacheOptions.flags.nonInteractive)
+        printer.print("\(plan.yellow)")
     }
 }
 

--- a/Sources/Rugby/Commands/Plan/Parser/DecodableModels/CacheDecodable.swift
+++ b/Sources/Rugby/Commands/Plan/Parser/DecodableModels/CacheDecodable.swift
@@ -24,6 +24,7 @@ struct CacheDecodable: Decodable {
     let hideMetrics: Bool?
     @BoolableIntDecodable var verbose: Int?
     let quiet: Bool?
+    let nonInteractive: Bool?
 }
 
 extension Cache {
@@ -47,5 +48,6 @@ extension Cache {
         self.flags.hideMetrics = decodable.hideMetrics ?? false
         self.flags.verbose = decodable.verbose ?? 0
         self.flags.quiet = decodable.quiet ?? false
+        self.flags.nonInteractive = decodable.nonInteractive ?? false
     }
 }

--- a/Sources/Rugby/Commands/Plan/Parser/DecodableModels/DropDecodable.swift
+++ b/Sources/Rugby/Commands/Plan/Parser/DecodableModels/DropDecodable.swift
@@ -17,6 +17,7 @@ struct DropDecodable: Decodable {
     let hideMetrics: Bool?
     @BoolableIntDecodable var verbose: Int?
     let quiet: Bool?
+    let nonInteractive: Bool?
 }
 
 extension Drop {
@@ -33,5 +34,6 @@ extension Drop {
         self.flags.hideMetrics = decodable.hideMetrics ?? false
         self.flags.verbose = decodable.verbose ?? 0
         self.flags.quiet = decodable.quiet ?? false
+        self.flags.nonInteractive = decodable.nonInteractive ?? false
     }
 }

--- a/Sources/Rugby/Commands/Plan/Parser/DecodableModels/FocusDecodable.swift
+++ b/Sources/Rugby/Commands/Plan/Parser/DecodableModels/FocusDecodable.swift
@@ -15,6 +15,7 @@ struct FocusDecodable: Decodable {
     let hideMetrics: Bool?
     @BoolableIntDecodable var verbose: Int?
     let quiet: Bool?
+    let nonInteractive: Bool?
 }
 
 extension Focus {
@@ -29,5 +30,6 @@ extension Focus {
         self.flags.hideMetrics = decodable.hideMetrics ?? false
         self.flags.verbose = decodable.verbose ?? 0
         self.flags.quiet = decodable.quiet ?? false
+        self.flags.nonInteractive = decodable.nonInteractive ?? false
     }
 }

--- a/Sources/Rugby/Commands/Plan/Parser/DecodableModels/ShellDecodable.swift
+++ b/Sources/Rugby/Commands/Plan/Parser/DecodableModels/ShellDecodable.swift
@@ -10,6 +10,7 @@ struct ShellDecodable: Decodable {
     let run: String
     @BoolableIntDecodable var verbose: Int?
     let quiet: Bool?
+    let nonInteractive: Bool?
 }
 
 extension Shell {
@@ -17,5 +18,6 @@ extension Shell {
         self.run = decodable.run
         self.verbose = decodable.verbose ?? 0
         self.quiet = decodable.quiet ?? false
+        self.nonInteractive = decodable.nonInteractive ?? false
     }
 }

--- a/Sources/Rugby/Commands/Plan/Subcommands/PlansReference.swift
+++ b/Sources/Rugby/Commands/Plan/Subcommands/PlansReference.swift
@@ -11,6 +11,7 @@ import Files
 struct PlansReference {
     let name: String
     let quiet = false
+    let nonInteractive = false
 }
 
 extension PlansReference: Command {

--- a/Sources/Rugby/Commands/Plan/Subcommands/PlansShell.swift
+++ b/Sources/Rugby/Commands/Plan/Subcommands/PlansShell.swift
@@ -12,9 +12,14 @@ struct Shell: Command {
     let run: String
     let verbose: Int
     let quiet: Bool
+    let nonInteractive: Bool
 
     func run(logFile: File) throws -> Metrics? {
-        let progress = RugbyPrinter(title: "Shell 🐚", logFile: logFile, verbose: .verbose, quiet: quiet)
+        let progress = RugbyPrinter(title: "Shell 🐚",
+                                    logFile: logFile,
+                                    verbose: .verbose,
+                                    quiet: quiet,
+                                    nonInteractive: nonInteractive)
         progress.print(run.yellow)
         if verbose.bool {
             try printShell(run)

--- a/Sources/Rugby/Commands/Rollback/Rollback.swift
+++ b/Sources/Rugby/Commands/Rollback/Rollback.swift
@@ -12,6 +12,8 @@ import Files
 struct Rollback: ParsableCommand, Command {
     @Flag(name: .shortAndLong, help: "Print more information.") var verbose: Int
     @Flag(name: .shortAndLong, help: "Print nothing.") var quiet = false
+    @Flag(help: "Format output for non-interactive terminal sessions (reduce loading spinner output).")
+    var nonInteractive = false
 
     static var configuration = CommandConfiguration(
         abstract: "• \("(Beta)".yellow) Deintegrate Rugby from your project."
@@ -26,7 +28,11 @@ struct Rollback: ParsableCommand, Command {
 
 extension Rollback {
     mutating func run(logFile: File) throws -> Metrics? {
-        let progress = RugbyPrinter(title: "Rollback", logFile: logFile, verbose: verbose, quiet: quiet)
+        let progress = RugbyPrinter(title: "Rollback",
+                                    logFile: logFile,
+                                    verbose: verbose,
+                                    quiet: quiet,
+                                    nonInteractive: nonInteractive)
         let backupManager = BackupManager(progress: progress)
         if verbose.bool {
             try backupManager.rollback()

--- a/Sources/Rugby/Common/Command/Command.swift
+++ b/Sources/Rugby/Common/Command/Command.swift
@@ -13,6 +13,7 @@ protocol Command {
     var project: String { get }
     var hideMetrics: Bool { get }
     var quiet: Bool { get }
+    var nonInteractive: Bool { get }
 
     mutating func run(logFile: File) throws -> Metrics?
 }

--- a/Sources/Rugby/Common/Command/CommonFlags.swift
+++ b/Sources/Rugby/Common/Command/CommonFlags.swift
@@ -13,4 +13,6 @@ struct CommonFlags: ParsableCommand {
     @Flag(help: "Hide metrics.") var hideMetrics = false
     @Flag(name: .shortAndLong, help: "Print more information.") var verbose: Int
     @Flag(name: .shortAndLong, help: "Print nothing.") var quiet = false
+    @Flag(help: "Format output for non-interactive terminal sessions (reduce loading spinner output).")
+    var nonInteractive = false
 }

--- a/Sources/Rugby/Common/Command/ParsableCommand+Metrics.swift
+++ b/Sources/Rugby/Common/Command/ParsableCommand+Metrics.swift
@@ -18,14 +18,14 @@ extension ParsableCommand {
 
     func outputShort(_ metrics: Metrics?, time: Double, logFile: File, quiet: Bool) {
         guard let metrics = metrics else { return }
-        let logger = RugbyPrinter(logFile: logFile, verbose: .verbose, quiet: quiet)
+        let logger = RugbyPrinter(logFile: logFile, verbose: .verbose, quiet: quiet, nonInteractive: false)
         if let short = metrics.short() {
             logger.print(time.output() + " " + short)
         }
     }
 
     func outputMore(_ metrics: Metrics, logFile: File, quiet: Bool) {
-        let logger = RugbyPrinter(logFile: logFile, verbose: .verbose, quiet: quiet)
+        let logger = RugbyPrinter(logFile: logFile, verbose: .verbose, quiet: quiet, nonInteractive: false)
         metrics.more().forEach {
             logger.print("[!] ".yellow + $0)
         }

--- a/Sources/Rugby/Common/Command/ParsableCommand+Output.swift
+++ b/Sources/Rugby/Common/Command/ParsableCommand+Output.swift
@@ -11,7 +11,7 @@ import Files
 
 extension ParsableCommand {
     func done(logFile: File, time: Double, quiet: Bool) {
-        let logger = RugbyPrinter(logFile: logFile, verbose: .verbose, quiet: quiet)
+        let logger = RugbyPrinter(logFile: logFile, verbose: .verbose, quiet: quiet, nonInteractive: false)
         logger.print(time.output() + " " + .finalMessage)
     }
 }

--- a/Sources/Rugby/Common/LogPrinter/Printers/RugbyPrinter.swift
+++ b/Sources/Rugby/Common/LogPrinter/Printers/RugbyPrinter.swift
@@ -57,7 +57,7 @@ final class RugbyPrinter: Printer {
         case .quiet:
             return try job()
         case .simple:
-            print(text)
+            print(text, level: .vv)
             return try job()
         case .standard:
             isSpinnerAnimating = true


### PR DESCRIPTION
### Description
CI or otherwise logged terminal sessions end up with a huge amount of output with stuff like `Build Building sim-x86_64` which various number of dots. For non-interactive sessions this loading spinner isn't as useful and bloats the output.

### References
N/A

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

❤️ Thanks for contributing to the 🏈 Rugby!
