### PR TITLE
🐛 Fixed checking that Xcode CLT set

### DIFF
--- a/Sources/Rugby/Commands/Cache/Steps/Prepare/CachePrepareStep.swift
+++ b/Sources/Rugby/Commands/Cache/Steps/Prepare/CachePrepareStep.swift
@@ -42,7 +42,7 @@ struct CachePrepareStep: Step {
 extension CachePrepareStep {
 
     func run(_ buildTarget: String) throws -> Output {
-        if try shell("xcode-select -p") == .defaultXcodeCLTPath {
+        if try shell("xcode-select -p").contains(String.defaultXcodeCLTPath) {
             throw CacheError.cantFindXcodeCommandLineTools
         }
 


### PR DESCRIPTION
### Description
Sometimes the default CLT path can contain whitespace characters.
I've made checking more flexible.

### References
None

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary

❤️ Thanks for contributing to the 🏈 Rugby!
