### PR TITLE
🎨 Print config name during building

### DIFF
--- a/Sources/Rugby/Commands/Cache/Steps/CacheBuildStep.swift
+++ b/Sources/Rugby/Commands/Cache/Steps/CacheBuildStep.swift
@@ -50,7 +50,7 @@ struct CacheBuildStep: Step {
 
         let xcargs = xcargsProvider.xcargs(bitcode: command.bitcode, withoutDebugSymbols: command.offDebugSymbols)
         for (sdk, arch) in zip(input.buildInfo.sdk, input.buildInfo.arch) {
-            try progress.spinner("Building \("\(sdk)-\(arch)".yellow)") {
+            try progress.spinner("Building \("\(sdk)-\(arch): \(command.config ?? "Debug")".yellow)") {
                 do {
                     try XcodeBuild(
                         project: .podsProject,


### PR DESCRIPTION
### Description
It's a tiny improvement which shows `config name` during building.
For example, `config: Staging With Spaces`.

<img width="452" alt="Screenshot 2022-10-07 at 21 14 27" src="https://user-images.githubusercontent.com/64660122/194601496-93af9ed0-a37c-4ec1-9397-c253208b04e0.png">

It can be useful when the project don't have `Debug` config as default one. Users can see error during building process and interrupt it.

### References
None

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary

❤️ Thanks for contributing to the 🏈 Rugby!
