### PR TITLE
🤖 Remove Xcode 12 build job

### DIFF
--- a/.github/workflows/regress.yml
+++ b/.github/workflows/regress.yml
@@ -35,15 +35,6 @@ jobs:
         with:
           name: rugby
           path: ${{ env.rugby_path }}
-
-  rugby-12:
-    runs-on: macos-10.15
-    steps:
-      - uses: actions/checkout@v2
-      - uses: maxim-lobanov/setup-xcode@v1
-        with: { xcode-version: '12.4' }
-      - name: Build Rugby
-        run: swift build -c release
 #==========================================================================
   cache-both:
     needs: rugby-13


### PR DESCRIPTION
### Description
> The macOS-10.15 environment is deprecated, consider switching to macos-11(macos-latest), macos-12 instead.
For more details see https://github.com/actions/virtual-environments/issues/5583

Unfortunately, I have to remove support Xcode 12.
If you can't update your mac OS and Xcode to newer version you can use `brew` for downloading 🏈 Rugby as a binary.
More information here: https://github.com/swiftyfinch/Rugby/discussions/71

### References
None

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary

❤️ Thanks for contributing to the 🏈 Rugby!
