### PR TITLE
🐛 Fixed video in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 <p align="center">
   <img src="https://user-images.githubusercontent.com/64660122/140398205-9328806e-897d-483d-a898-c90f66840196.png" width="600"/>
 </p>
+
 <p align="center">
-  <img src="https://user-images.githubusercontent.com/64660122/141674975-22c970d6-943e-49cc-a86a-42276b3520e8.mp4" width="600"/>
+   <img src="https://user-images.githubusercontent.com/64660122/194708589-7331a02a-6d6e-4c0f-a7ec-e367f7228080.gif" width="600"/>
 </p>
+
 <p align="center">
   <a href="https://swiftpackageindex.com/swiftyfinch/Rugby"><img src="https://img.shields.io/endpoint?color=orange&label=Swift&logo=swift&logoColor=white&url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fswiftyfinch%2FRugby%2Fbadge%3Ftype%3Dswift-versions" /></a>
   <a href="https://swiftpackageindex.com/swiftyfinch/Rugby"><img src="https://img.shields.io/endpoint?label=Platform&url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fswiftyfinch%2FRugby%2Fbadge%3Ftype%3Dplatforms" /></a>


### PR DESCRIPTION
<!--
    Hello!

    Before you submit your request, please replace the paragraph
    below with the relevant details, and complete the steps in the
    checklist by placing an 'x' in each box:
    
    - [x] I've completed this task
    - [ ] This task isn't completed
    
    Provide links to an existing issue or external references/discussions, if appropriate.
-->

### Description

The video in the README was just showing as the broken file icon on Firefox and Chrome.

<img width="791" alt="image" src="https://user-images.githubusercontent.com/168025/194706682-e77f40a8-71ef-4cd0-bdde-596cb3501792.png">

### Checklist
- [ ] I've added at least one test that validates that my change is working, if appropriate
- [ ] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

❤️ Thanks for contributing to the 🏈 Rugby!
