### PR TITLE
Add ARCH.generic

### DIFF
--- a/Docs/Cache.md
+++ b/Docs/Cache.md
@@ -6,7 +6,9 @@ OVERVIEW: Convert pods to prebuilt dependencies.
 
 OPTIONS:
   -s, --sdk <sdk>         Build sdks: sim/ios or both. (default: sim)
-  -a, --arch <arch>       Build architectures. (default: sim x86_64, ios arm64. In particular, sim auto means x86_64 on x86 mac, arm64 on arm64 mac)
+  -a, --arch <arch>       Build architectures. (default: [sim x86_64], [ios arm64].
+                          In particular, [sim auto] means x86_64 on x86 mac, arm64 on arm64 mac.
+                          In some case, build sim with arch wouldn't work properly. You can use [sim generic].)
   -c, --config <config>   Build configuration. (default: Debug)
   --bitcode               Add bitcode for archive builds.
   -k, --keep-sources      Keep Pods group in project.

--- a/Docs/Cache.md
+++ b/Docs/Cache.md
@@ -8,7 +8,7 @@ OPTIONS:
   -s, --sdk <sdk>         Build sdks: sim/ios or both. (default: sim)
   -a, --arch <arch>       Build architectures. (default: [sim x86_64], [ios arm64].
                           In particular, [sim auto] means x86_64 on x86 mac, arm64 on arm64 mac.
-                          In some case, build sim with arch wouldn't work properly. You can use [sim generic].)
+                          In some case, build sim with arch would not work properly. You can use [sim generic].)
   -c, --config <config>   Build configuration. (default: Debug)
   --bitcode               Add bitcode for archive builds.
   -k, --keep-sources      Keep Pods group in project.

--- a/Docs/Plans.md
+++ b/Docs/Plans.md
@@ -10,7 +10,7 @@ OPTIONS:
   -s, --sdk <sdk>         Build sdks: sim/ios or both. (default: sim)
   -a, --arch <arch>       Build architectures. (default: [sim x86_64], [ios arm64].
                           In particular, [sim auto] means x86_64 on x86 mac, arm64 on arm64 mac.
-                          In some case, build sim with arch wouldn't work properly. You can use [sim generic].)
+                          In some case, build sim with arch would not work properly. You can use [sim generic].)
   -c, --config <config>   Build configuration. (default: Debug)
   --bitcode               Add bitcode for archive builds.
   -k, --keep-sources      Keep Pods group in project.
@@ -68,7 +68,7 @@ rugby example
   - command: cache
     # Optional parameters with default values:
     graph: true
-    arch: [] # By default: [sim x86_64], [ios arm64]. In particular, [sim auto] means x86_64 on x86 mac, arm64 on arm64 mac. In some case, build sim with arch wouldn't work properly. You can use [sim generic].
+    arch: [] # By default: [sim x86_64], [ios arm64]. In particular, [sim auto] means x86_64 on x86 mac, arm64 on arm64 mac. In some case, build sim with arch would not work properly. You can use [sim generic].
     config: null # By default Debug
     sdk: [sim]
     bitcode: false

--- a/Docs/Plans.md
+++ b/Docs/Plans.md
@@ -8,7 +8,9 @@ OPTIONS:
   --plan <plan>           Plan name. (default: the first plan)
 
   -s, --sdk <sdk>         Build sdks: sim/ios or both. (default: sim)
-  -a, --arch <arch>       Build architectures. (default: sim x86_64, ios arm64)
+  -a, --arch <arch>       Build architectures. (default: [sim x86_64], [ios arm64].
+                          In particular, [sim auto] means x86_64 on x86 mac, arm64 on arm64 mac.
+                          In some case, build sim with arch wouldn't work properly. You can use [sim generic].)
   -c, --config <config>   Build configuration. (default: Debug)
   --bitcode               Add bitcode for archive builds.
   -k, --keep-sources      Keep Pods group in project.
@@ -66,7 +68,7 @@ rugby example
   - command: cache
     # Optional parameters with default values:
     graph: true
-    arch: [] # By default: sim x86_64, ios arm64. In particular, sim auto means x86_64 on x86 mac, arm64 on arm64 mac.
+    arch: [] # By default: [sim x86_64], [ios arm64]. In particular, [sim auto] means x86_64 on x86 mac, arm64 on arm64 mac. In some case, build sim with arch wouldn't work properly. You can use [sim generic].
     config: null # By default Debug
     sdk: [sim]
     bitcode: false

--- a/Sources/Rugby/Commands/Cache/Other/Build/XcodeBuild.swift
+++ b/Sources/Rugby/Commands/Cache/Other/Build/XcodeBuild.swift
@@ -26,10 +26,10 @@ struct XcodeBuild {
         ]
         arguments.append(contentsOf: xcargs)
 
-		if var arch = arch, arch != ARCH.generic {
-			if arch == "auto" {
-				arch = sdk.defaultARCH
-			}
+        if var arch = arch, arch != ARCH.generic {
+            if arch == "auto" {
+                arch = sdk.defaultARCH
+            }
             arguments.append("ARCHS=\(arch)")
         }
         if let config = config {

--- a/Sources/Rugby/Commands/Cache/Other/Build/XcodeBuild.swift
+++ b/Sources/Rugby/Commands/Cache/Other/Build/XcodeBuild.swift
@@ -26,7 +26,7 @@ struct XcodeBuild {
         ]
         arguments.append(contentsOf: xcargs)
 
-        if var arch = arch {
+		if var arch = arch, arch != ARCH.generic {
 			if arch == "auto" {
 				arch = sdk.defaultARCH
 			}

--- a/Sources/Rugby/Common/Environment/ARCH.swift
+++ b/Sources/Rugby/Common/Environment/ARCH.swift
@@ -8,5 +8,5 @@
 enum ARCH {
     static let x86_64 = "x86_64" // swiftlint:disable:this identifier_name
     static let arm64 = "arm64"
-	static let generic = "generic"
+    static let generic = "generic"
 }

--- a/Sources/Rugby/Common/Environment/ARCH.swift
+++ b/Sources/Rugby/Common/Environment/ARCH.swift
@@ -8,4 +8,5 @@
 enum ARCH {
     static let x86_64 = "x86_64" // swiftlint:disable:this identifier_name
     static let arm64 = "arm64"
+	static let generic = "generic"
 }


### PR DESCRIPTION
### Description
In some case, build sim with arch wouldn't work properly. Add `generic` ARCH to build without arch.

### References
In my project, build [sim x86] may not build success sometime. It says need arm64 but found x86_64. It's better build without ARCH to support old project running on simulotor.

### Checklist
- [x] I've added at least one test that validates that my change is working, if appropriate
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

❤️ Thanks for contributing to the 🏈 Rugby!
