### PR TITLE
🐛 Fix path replacement issue

### DIFF
--- a/Sources/RugbyFoundation/Core/Use/FileContentEditor.swift
+++ b/Sources/RugbyFoundation/Core/Use/FileContentEditor.swift
@@ -2,33 +2,32 @@ import Fish
 import Foundation
 
 final class FileContentEditor {
-
     func replace(_ replacements: [String: String], regex: NSRegularExpression, filePath: String) throws {
         guard File.isExist(at: filePath) else { return }
         let file = try File.at(filePath)
         try replace(replacements, regex: regex, file: file)
     }
-    
+
     func replace(_ replacements: [String: String], regex: NSRegularExpression, file: IFile) throws {
         let content = try file.read()
         let matches = regex.matches(in: content, range: NSRange(content.startIndex..., in: content))
         guard matches.isNotEmpty else { return }
-        
+
         var newContent: String = ""
         var cursor = content.startIndex
         for match in matches {
             guard let range = Range(match.range, in: content) else { continue }
-            
+
             let prefix = content[cursor ..< range.lowerBound]
             newContent.append(contentsOf: prefix)
             cursor = range.upperBound
-            
+
             let lookup = String(content[range])
             if let replacement = replacements[lookup] {
                 newContent.append(contentsOf: replacement)
             }
         }
-        
+
         let suffix = content[cursor ..< content.endIndex]
         newContent.append(contentsOf: suffix)
         try file.write(newContent)

--- a/Sources/RugbyFoundation/Core/Use/FileContentEditor.swift
+++ b/Sources/RugbyFoundation/Core/Use/FileContentEditor.swift
@@ -4,11 +4,8 @@ import Foundation
 final class FileContentEditor {
     func replace(_ replacements: [String: String], regex: NSRegularExpression, filePath: String) throws {
         guard File.isExist(at: filePath) else { return }
-        let file = try File.at(filePath)
-        try replace(replacements, regex: regex, file: file)
-    }
 
-    func replace(_ replacements: [String: String], regex: NSRegularExpression, file: IFile) throws {
+        let file = try File.at(filePath)
         let content = try file.read()
         let matches = regex.matches(in: content, range: NSRange(content.startIndex..., in: content))
         guard matches.isNotEmpty else { return }

--- a/Sources/RugbyFoundation/Core/Use/FileContentEditor.swift
+++ b/Sources/RugbyFoundation/Core/Use/FileContentEditor.swift
@@ -2,32 +2,33 @@ import Fish
 import Foundation
 
 final class FileContentEditor {
-    private let separator = "\""
-    private let tokenPrefix = "${"
 
     func replace(_ replacements: [String: String], regex: NSRegularExpression, filePath: String) throws {
         guard File.isExist(at: filePath) else { return }
-
         let file = try File.at(filePath)
+        try replace(replacements, regex: regex, file: file)
+    }
+    
+    func replace(_ replacements: [String: String], regex: NSRegularExpression, file: IFile) throws {
         let content = try file.read()
         let matches = regex.matches(in: content, range: NSRange(content.startIndex..., in: content))
         guard matches.isNotEmpty else { return }
-
+        
         var newContent: String = ""
         var cursor = content.startIndex
         for match in matches {
             guard let range = Range(match.range, in: content) else { continue }
-
+            
             let prefix = content[cursor ..< range.lowerBound]
             newContent.append(contentsOf: prefix)
             cursor = range.upperBound
-
+            
             let lookup = String(content[range])
             if let replacement = replacements[lookup] {
                 newContent.append(contentsOf: replacement)
             }
         }
-
+        
         let suffix = content[cursor ..< content.endIndex]
         newContent.append(contentsOf: suffix)
         try file.write(newContent)

--- a/Sources/RugbyFoundation/Utils/Internal/Extensions/Foundation/String+RegEx.swift
+++ b/Sources/RugbyFoundation/Utils/Internal/Extensions/Foundation/String+RegEx.swift
@@ -5,6 +5,10 @@ enum RegexError: Error {
 }
 
 extension String {
+    var escapedPattern: String {
+        NSRegularExpression.escapedPattern(for: self)
+    }
+
     func regex() throws -> NSRegularExpression {
         try NSRegularExpression(pattern: self, options: .anchorsMatchLines)
     }

--- a/Sources/RugbyFoundation/Utils/Internal/Extensions/Swift/String/String+Quotes.swift
+++ b/Sources/RugbyFoundation/Utils/Internal/Extensions/Swift/String/String+Quotes.swift
@@ -1,5 +1,0 @@
-extension String {
-    var quoted: String {
-        #""\#(self)""#
-    }
-}

--- a/Tests/FoundationTests/Core/Use/FileContentEditorTests.swift
+++ b/Tests/FoundationTests/Core/Use/FileContentEditorTests.swift
@@ -1,13 +1,13 @@
-import XCTest
 @testable import RugbyFoundation
+import XCTest
 
 final class FileContentEditorTests: XCTestCase {
     private var sut: FileContentEditor!
-    
+
     override func setUpWithError() throws {
         sut = FileContentEditor()
     }
-    
+
     override func tearDownWithError() throws {
         sut = nil
     }
@@ -18,26 +18,32 @@ extension FileContentEditorTests {
         var newContent = ""
         let file = IFileMock()
         file.writeClosure = { newContent = $0 }
+        // swiftlint:disable line_length
         file.readClosure = {
-        """
-FRAMEWORK_SEARCH_PATH = $(Inherited) "${PODS_CONFIGURATION_BUILD_DIR}/Realm-library"
-HEADER_SEARCH_PATH = $(Inherited) ${PODS_CONFIGURATION_BUILD_DIR}/Realm-library/libRealm-library.a/Headers '${PODS_CONFIGURATION_BUILD_DIR}/Moya/Moya.framework/Headers'
-"""
+            """
+            FRAMEWORK_SEARCH_PATH = $(Inherited) "${PODS_CONFIGURATION_BUILD_DIR}/Realm-library"
+            HEADER_SEARCH_PATH = $(Inherited) ${PODS_CONFIGURATION_BUILD_DIR}/Realm-library/libRealm-library.a/Headers '${PODS_CONFIGURATION_BUILD_DIR}/Moya/Moya.framework/Headers'
+            """
         }
         let replacements = [
-            "${PODS_CONFIGURATION_BUILD_DIR}/Realm-library": "${HOME}/.rugby/bin/Realm-library/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/d2d48c5",
-            "${PODS_CONFIGURATION_BUILD_DIR}/Realm-library/libRealm-library.a/Headers": "${HOME}/.rugby/bin/Realm-library/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/d2d48c5/libRealm-library.a/Headers",
-            "${PODS_CONFIGURATION_BUILD_DIR}/Moya/Moya.framework/Headers": "${HOME}/.rugby/bin/Moya/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/badaa58/Moya.framework/Headers"
+            "${PODS_CONFIGURATION_BUILD_DIR}/Realm-library":
+                "${HOME}/.rugby/bin/Realm-library/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/d2d48c5",
+            "${PODS_CONFIGURATION_BUILD_DIR}/Realm-library/libRealm-library.a/Headers":
+                "${HOME}/.rugby/bin/Realm-library/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/d2d48c5/libRealm-library.a/Headers",
+            "${PODS_CONFIGURATION_BUILD_DIR}/Moya/Moya.framework/Headers":
+                "${HOME}/.rugby/bin/Moya/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/badaa58/Moya.framework/Headers"
         ]
         let regexPattern = try #"(\$\{PODS_CONFIGURATION_BUILD_DIR\}/Realm-library|\$\{PODS_CONFIGURATION_BUILD_DIR\}/Realm-library/libRealm-library\.a/Headers|\$\{PODS_CONFIGURATION_BUILD_DIR\}/Moya/Moya\.framework/Headers)\b"#.regex()
-        
+        let expectedNewContent = """
+        FRAMEWORK_SEARCH_PATH = $(Inherited) "${HOME}/.rugby/bin/Realm-library/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/d2d48c5"
+        HEADER_SEARCH_PATH = $(Inherited) ${HOME}/.rugby/bin/Realm-library/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/d2d48c5/libRealm-library.a/Headers '${HOME}/.rugby/bin/Moya/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/badaa58/Moya.framework/Headers'
+        """
+        // swiftlint:enable line_length
+
         // Act
         try sut.replace(replacements, regex: regexPattern, file: file)
-        
+
         // Assert
-        XCTAssertEqual(newContent, """
-FRAMEWORK_SEARCH_PATH = $(Inherited) "${HOME}/.rugby/bin/Realm-library/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/d2d48c5"
-HEADER_SEARCH_PATH = $(Inherited) ${HOME}/.rugby/bin/Realm-library/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/d2d48c5/libRealm-library.a/Headers '${HOME}/.rugby/bin/Moya/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/badaa58/Moya.framework/Headers'
-""")
+        XCTAssertEqual(newContent, expectedNewContent)
     }
 }

--- a/Tests/FoundationTests/Core/Use/FileContentEditorTests.swift
+++ b/Tests/FoundationTests/Core/Use/FileContentEditorTests.swift
@@ -42,7 +42,9 @@ extension FileContentEditorTests {
             "${PODS_CONFIGURATION_BUILD_DIR}/Moya/Moya.framework/Headers":
                 "${HOME}/.rugby/bin/Moya/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/badaa58/Moya.framework/Headers"
         ]
-        let regexPattern = try #"(\$\{PODS_CONFIGURATION_BUILD_DIR\}/Realm-library|\$\{PODS_CONFIGURATION_BUILD_DIR\}/Realm-library/libRealm-library\.a/Headers|\$\{PODS_CONFIGURATION_BUILD_DIR\}/Moya/Moya\.framework/Headers)\b"#.regex()
+        let joinedReplacementStr = #"(\$\{PODS_CONFIGURATION_BUILD_DIR\}/Realm-library|\$\{PODS_CONFIGURATION_BUILD_DIR\}/Realm-library/libRealm-library\.a/Headers|\$\{PODS_CONFIGURATION_BUILD_DIR\}/Moya/Moya\.framework/Headers)"#
+        // Ensured that the validation method here matches the matching approach in SupportFilesPatcher.
+        let regexPattern = try "\(ReplacementBoundary.prefix)\(joinedReplacementStr)\(ReplacementBoundary.suffix)".regex()
         let expectedNewContent = """
         FRAMEWORK_SEARCH_PATH = $(Inherited) "${HOME}/.rugby/bin/Realm-library/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/d2d48c5"
         HEADER_SEARCH_PATH = $(Inherited) ${HOME}/.rugby/bin/Realm-library/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/d2d48c5/libRealm-library.a/Headers '${HOME}/.rugby/bin/Moya/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/badaa58/Moya.framework/Headers'

--- a/Tests/FoundationTests/Core/Use/FileContentEditorTests.swift
+++ b/Tests/FoundationTests/Core/Use/FileContentEditorTests.swift
@@ -1,15 +1,24 @@
+import Fish
 @testable import RugbyFoundation
 import XCTest
 
 final class FileContentEditorTests: XCTestCase {
     private var sut: FileContentEditor!
+    private var fishSharedStorage: IFilesManagerMock!
 
     override func setUpWithError() throws {
+        fishSharedStorage = IFilesManagerMock()
+        let backupFishSharedStorage = Fish.sharedStorage
+        Fish.sharedStorage = fishSharedStorage
+        addTeardownBlock {
+            Fish.sharedStorage = backupFishSharedStorage
+        }
         sut = FileContentEditor()
     }
 
     override func tearDownWithError() throws {
         sut = nil
+        fishSharedStorage = nil
     }
 }
 
@@ -39,9 +48,11 @@ extension FileContentEditorTests {
         HEADER_SEARCH_PATH = $(Inherited) ${HOME}/.rugby/bin/Realm-library/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/d2d48c5/libRealm-library.a/Headers '${HOME}/.rugby/bin/Moya/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/badaa58/Moya.framework/Headers'
         """
         // swiftlint:enable line_length
+        fishSharedStorage.isItemExistAtClosure = { _ in true }
+        fishSharedStorage.fileAtClosure = { _ in file }
 
         // Act
-        try sut.replace(replacements, regex: regexPattern, file: file)
+        try sut.replace(replacements, regex: regexPattern, filePath: "/test/path")
 
         // Assert
         XCTAssertEqual(newContent, expectedNewContent)

--- a/Tests/FoundationTests/Core/Use/FileContentEditorTests.swift
+++ b/Tests/FoundationTests/Core/Use/FileContentEditorTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import RugbyFoundation
+
+final class FileContentEditorTests: XCTestCase {
+    private var sut: FileContentEditor!
+    
+    override func setUpWithError() throws {
+        sut = FileContentEditor()
+    }
+    
+    override func tearDownWithError() throws {
+        sut = nil
+    }
+}
+
+extension FileContentEditorTests {
+    func test_replace_pathFormat() throws {
+        var newContent = ""
+        let file = IFileMock()
+        file.writeClosure = { newContent = $0 }
+        file.readClosure = {
+        """
+FRAMEWORK_SEARCH_PATH = $(Inherited) "${PODS_CONFIGURATION_BUILD_DIR}/Realm-library"
+HEADER_SEARCH_PATH = $(Inherited) ${PODS_CONFIGURATION_BUILD_DIR}/Realm-library/libRealm-library.a/Headers '${PODS_CONFIGURATION_BUILD_DIR}/Moya/Moya.framework/Headers'
+"""
+        }
+        let replacements = [
+            "${PODS_CONFIGURATION_BUILD_DIR}/Realm-library": "${HOME}/.rugby/bin/Realm-library/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/d2d48c5",
+            "${PODS_CONFIGURATION_BUILD_DIR}/Realm-library/libRealm-library.a/Headers": "${HOME}/.rugby/bin/Realm-library/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/d2d48c5/libRealm-library.a/Headers",
+            "${PODS_CONFIGURATION_BUILD_DIR}/Moya/Moya.framework/Headers": "${HOME}/.rugby/bin/Moya/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/badaa58/Moya.framework/Headers"
+        ]
+        let regexPattern = try #"(\$\{PODS_CONFIGURATION_BUILD_DIR\}/Realm-library|\$\{PODS_CONFIGURATION_BUILD_DIR\}/Realm-library/libRealm-library\.a/Headers|\$\{PODS_CONFIGURATION_BUILD_DIR\}/Moya/Moya\.framework/Headers)\b"#.regex()
+        
+        // Act
+        try sut.replace(replacements, regex: regexPattern, file: file)
+        
+        // Assert
+        XCTAssertEqual(newContent, """
+FRAMEWORK_SEARCH_PATH = $(Inherited) "${HOME}/.rugby/bin/Realm-library/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/d2d48c5"
+HEADER_SEARCH_PATH = $(Inherited) ${HOME}/.rugby/bin/Realm-library/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/d2d48c5/libRealm-library.a/Headers '${HOME}/.rugby/bin/Moya/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/badaa58/Moya.framework/Headers'
+""")
+    }
+}

--- a/Tests/FoundationTests/Core/Use/SupportFilesPatcherTests.swift
+++ b/Tests/FoundationTests/Core/Use/SupportFilesPatcherTests.swift
@@ -3,6 +3,8 @@ import XCTest
 
 final class SupportFilesPatcherTests: XCTestCase {
     private var sut: ISupportFilesPatcher!
+    private var expectedPrefixBoundary = #"(?<=(\"|'|\s))"#
+    private var expectedSuffixBoundary = #"(?=(\"|'|\s))"#
 
     override func setUp() {
         super.setUp()
@@ -62,11 +64,14 @@ extension SupportFilesPatcherTests {
         let target = Target.podsExample
         // swiftlint:disable line_length
         let xcconfigReplacements = ["${PODS_CONFIGURATION_BUILD_DIR}/Realm-library": "${HOME}/.rugby/bin/Realm-library/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/d2d48c5", "${PODS_CONFIGURATION_BUILD_DIR}/Realm-library/Realm_library.modulemap": "${HOME}/.rugby/bin/Realm-library/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/d2d48c5/Realm_library.modulemap", "${PODS_CONFIGURATION_BUILD_DIR}/Alamofire": "${HOME}/.rugby/bin/Alamofire/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/36ff0bc", "${PODS_CONFIGURATION_BUILD_DIR}/Moya/Moya.modulemap": "${HOME}/.rugby/bin/Moya/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/badaa58/Moya.modulemap", "${PODS_CONFIGURATION_BUILD_DIR}/Moya": "${HOME}/.rugby/bin/Moya/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/badaa58", "${PODS_CONFIGURATION_BUILD_DIR}/Realm-library/libRealm-library.a/Headers": "${HOME}/.rugby/bin/Realm-library/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/d2d48c5/libRealm-library.a/Headers", "${PODS_CONFIGURATION_BUILD_DIR}/Alamofire/Alamofire.modulemap": "${HOME}/.rugby/bin/Alamofire/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/36ff0bc/Alamofire.modulemap", "${PODS_XCFRAMEWORKS_BUILD_DIR}/Realm-library": "${HOME}/.rugby/bin/Realm-library/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/d2d48c5/Realm-library", "${PODS_CONFIGURATION_BUILD_DIR}/Moya/Moya.framework/Headers": "${HOME}/.rugby/bin/Moya/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/badaa58/Moya.framework/Headers", "${PODS_CONFIGURATION_BUILD_DIR}/Alamofire/Alamofire.framework/Headers": "${HOME}/.rugby/bin/Alamofire/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/36ff0bc/Alamofire.framework/Headers", "${PODS_XCFRAMEWORKS_BUILD_DIR}/Realm-library/Headers": "${HOME}/.rugby/bin/Realm-library/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/d2d48c5/Realm-library/Headers"]
-        let xcconfigRegexPattern = #"(\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Moya\/Moya\.framework\/Headers|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Moya|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Moya\/Moya\.modulemap|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Alamofire\/Alamofire\.framework\/Headers|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Alamofire|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Alamofire\/Alamofire\.modulemap|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Realm-library\/libRealm-library\.a\/Headers|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Realm-library|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Realm-library\/Realm_library\.modulemap|\$\{PODS_XCFRAMEWORKS_BUILD_DIR\}\/Realm-library\/Headers|\$\{PODS_XCFRAMEWORKS_BUILD_DIR\}\/Realm-library)\b"#
+        let xcconfigRegexPattern = expectedPrefixBoundary + #"(\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Moya\/Moya\.framework\/Headers|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Moya|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Moya\/Moya\.modulemap|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Alamofire\/Alamofire\.framework\/Headers|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Alamofire|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Alamofire\/Alamofire\.modulemap|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Realm-library\/libRealm-library\.a\/Headers|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Realm-library|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Realm-library\/Realm_library\.modulemap|\$\{PODS_XCFRAMEWORKS_BUILD_DIR\}\/Realm-library\/Headers|\$\{PODS_XCFRAMEWORKS_BUILD_DIR\}\/Realm-library)"# + expectedSuffixBoundary
         let frameworkReplacements = ["${BUILT_PRODUCTS_DIR}/Moya/Moya.framework": "${HOME}/.rugby/bin/Moya/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/badaa58/Moya.framework", "${BUILT_PRODUCTS_DIR}/Realm-library/libRealm-library.a": "${HOME}/.rugby/bin/Realm-library/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/d2d48c5/libRealm-library.a", "${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework": "${HOME}/.rugby/bin/Alamofire/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/36ff0bc/Alamofire.framework"]
-        let frameworksRegexPattern = #"\$\{BUILT_PRODUCTS_DIR\}\/(Moya\/Moya\.framework|Alamofire\/Alamofire\.framework|Realm-library\/libRealm-library\.a)\b"#
+        let frameworksRegexPattern = expectedPrefixBoundary + #"\$\{BUILT_PRODUCTS_DIR\}\/(Moya\/Moya\.framework|Alamofire\/Alamofire\.framework|Realm-library\/libRealm-library\.a)"# + expectedSuffixBoundary
         let resourcesReplacements = ["${BUILT_PRODUCTS_DIR}/Realm-library/libRealm-library.a/": "${HOME}/.rugby/bin/Realm-library/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/d2d48c5/libRealm-library.a/", "${BUILT_PRODUCTS_DIR}/Moya/Moya.framework/": "${HOME}/.rugby/bin/Moya/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/badaa58/Moya.framework/", "${PODS_CONFIGURATION_BUILD_DIR}/LocalPod/LocalPodResources.bundle": "${HOME}/.rugby/bin/LocalPodResources/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/17da84b/LocalPodResources.bundle", "${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework/": "${HOME}/.rugby/bin/Alamofire/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/36ff0bc/Alamofire.framework/"]
-        let resourcesRegexPattern = #"(\$\{PODS_CONFIGURATION_BUILD_DIR\}\/(LocalPod\/LocalPodResources\.bundle)\b|\$\{BUILT_PRODUCTS_DIR\}\/(Moya\/Moya\.framework\/|Alamofire\/Alamofire\.framework\/|Realm-library\/libRealm-library\.a\/))"#
+        let resourcesRegexPattern = "(" + expectedPrefixBoundary
+            + #"\$\{PODS_CONFIGURATION_BUILD_DIR\}\/(LocalPod\/LocalPodResources\.bundle)"#
+            + expectedSuffixBoundary
+            + #"|\$\{BUILT_PRODUCTS_DIR\}\/(Moya\/Moya\.framework\/|Alamofire\/Alamofire\.framework\/|Realm-library\/libRealm-library\.a\/))"#
         // swiftlint:enable line_length
 
         // Act
@@ -111,8 +116,10 @@ private extension SupportFilesPatcherTests {
     }
 
     private var localPodXCConfigRegexPattern: String {
-        // swiftlint:disable:next line_length
-        #"(\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Moya\/Moya\.framework\/Headers|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Moya|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Moya\/Moya\.modulemap|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Alamofire\/Alamofire\.framework\/Headers|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Alamofire|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Alamofire\/Alamofire\.modulemap)\b"#
+        expectedPrefixBoundary
+            // swiftlint:disable:next line_length
+            + #"(\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Moya\/Moya\.framework\/Headers|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Moya|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Moya\/Moya\.modulemap|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Alamofire\/Alamofire\.framework\/Headers|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Alamofire|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Alamofire\/Alamofire\.modulemap)"#
+            + expectedSuffixBoundary
     }
 
     private var frameworkReplacements: [String: String] {
@@ -128,7 +135,9 @@ private extension SupportFilesPatcherTests {
     }
 
     private var frameworksRegexPattern: String {
-        #"\$\{BUILT_PRODUCTS_DIR\}\/(Moya\/Moya\.framework|Alamofire\/Alamofire\.framework)\b"#
+        expectedPrefixBoundary
+            + #"\$\{BUILT_PRODUCTS_DIR\}\/(Moya\/Moya\.framework|Alamofire\/Alamofire\.framework)"#
+            + expectedSuffixBoundary
     }
 
     private var resourcesReplacements: [String: String] {
@@ -145,8 +154,11 @@ private extension SupportFilesPatcherTests {
     }
 
     private var resourcesRegexPattern: String {
-        // swiftlint:disable:next line_length
-        #"(\$\{PODS_CONFIGURATION_BUILD_DIR\}\/(LocalPod\/LocalPodResources\.bundle)\b|\$\{BUILT_PRODUCTS_DIR\}\/(Moya\/Moya\.framework\/|Alamofire\/Alamofire\.framework\/))"#
+        "("
+            + expectedPrefixBoundary
+            + #"\$\{PODS_CONFIGURATION_BUILD_DIR\}\/(LocalPod\/LocalPodResources\.bundle)"#
+            + expectedSuffixBoundary
+            + #"|\$\{BUILT_PRODUCTS_DIR\}\/(Moya\/Moya\.framework\/|Alamofire\/Alamofire\.framework\/))"#
     }
 }
 

--- a/Tests/FoundationTests/Core/Use/SupportFilesPatcherTests.swift
+++ b/Tests/FoundationTests/Core/Use/SupportFilesPatcherTests.swift
@@ -61,12 +61,12 @@ extension SupportFilesPatcherTests {
     func test_prepareReplacements_umbrella() throws {
         let target = Target.podsExample
         // swiftlint:disable line_length
-        let xcconfigReplacements = ["\"${PODS_CONFIGURATION_BUILD_DIR}/Realm-library\"": "\"${HOME}/.rugby/bin/Realm-library/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/d2d48c5\"", "\"${PODS_CONFIGURATION_BUILD_DIR}/Realm-library/Realm_library.modulemap\"": "\"${HOME}/.rugby/bin/Realm-library/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/d2d48c5/Realm_library.modulemap\"", "\"${PODS_CONFIGURATION_BUILD_DIR}/Alamofire\"": "\"${HOME}/.rugby/bin/Alamofire/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/36ff0bc\"", "\"${PODS_CONFIGURATION_BUILD_DIR}/Moya/Moya.modulemap\"": "\"${HOME}/.rugby/bin/Moya/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/badaa58/Moya.modulemap\"", "\"${PODS_CONFIGURATION_BUILD_DIR}/Moya\"": "\"${HOME}/.rugby/bin/Moya/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/badaa58\"", "\"${PODS_CONFIGURATION_BUILD_DIR}/Realm-library/libRealm-library.a/Headers\"": "\"${HOME}/.rugby/bin/Realm-library/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/d2d48c5/libRealm-library.a/Headers\"", "\"${PODS_CONFIGURATION_BUILD_DIR}/Alamofire/Alamofire.modulemap\"": "\"${HOME}/.rugby/bin/Alamofire/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/36ff0bc/Alamofire.modulemap\"", "\"${PODS_XCFRAMEWORKS_BUILD_DIR}/Realm-library\"": "\"${HOME}/.rugby/bin/Realm-library/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/d2d48c5/Realm-library\"", "\"${PODS_CONFIGURATION_BUILD_DIR}/Moya/Moya.framework/Headers\"": "\"${HOME}/.rugby/bin/Moya/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/badaa58/Moya.framework/Headers\"", "\"${PODS_CONFIGURATION_BUILD_DIR}/Alamofire/Alamofire.framework/Headers\"": "\"${HOME}/.rugby/bin/Alamofire/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/36ff0bc/Alamofire.framework/Headers\"", "\"${PODS_XCFRAMEWORKS_BUILD_DIR}/Realm-library/Headers\"": "\"${HOME}/.rugby/bin/Realm-library/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/d2d48c5/Realm-library/Headers\""]
-        let xcconfigRegexPattern = #""(\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Moya\/Moya\.framework\/Headers|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Moya|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Moya\/Moya\.modulemap|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Alamofire\/Alamofire\.framework\/Headers|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Alamofire|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Alamofire\/Alamofire\.modulemap|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Realm-library\/libRealm-library\.a\/Headers|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Realm-library|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Realm-library\/Realm_library\.modulemap|\$\{PODS_XCFRAMEWORKS_BUILD_DIR\}\/Realm-library\/Headers|\$\{PODS_XCFRAMEWORKS_BUILD_DIR\}\/Realm-library)""#
-        let frameworkReplacements = ["\"${BUILT_PRODUCTS_DIR}/Moya/Moya.framework\"": "\"${HOME}/.rugby/bin/Moya/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/badaa58/Moya.framework\"", "\"${BUILT_PRODUCTS_DIR}/Realm-library/libRealm-library.a\"": "\"${HOME}/.rugby/bin/Realm-library/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/d2d48c5/libRealm-library.a\"", "\"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework\"": "\"${HOME}/.rugby/bin/Alamofire/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/36ff0bc/Alamofire.framework\""]
-        let frameworksRegexPattern = #""\$\{BUILT_PRODUCTS_DIR\}\/(Moya\/Moya\.framework|Alamofire\/Alamofire\.framework|Realm-library\/libRealm-library\.a)""#
-        let resourcesReplacements = ["${BUILT_PRODUCTS_DIR}/Realm-library/libRealm-library.a/": "${HOME}/.rugby/bin/Realm-library/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/d2d48c5/libRealm-library.a/", "${BUILT_PRODUCTS_DIR}/Moya/Moya.framework/": "${HOME}/.rugby/bin/Moya/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/badaa58/Moya.framework/", "\"${PODS_CONFIGURATION_BUILD_DIR}/LocalPod/LocalPodResources.bundle\"": "\"${HOME}/.rugby/bin/LocalPodResources/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/17da84b/LocalPodResources.bundle\"", "${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework/": "${HOME}/.rugby/bin/Alamofire/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/36ff0bc/Alamofire.framework/"]
-        let resourcesRegexPattern = #"("\$\{PODS_CONFIGURATION_BUILD_DIR\}\/(LocalPod\/LocalPodResources\.bundle)"|\$\{BUILT_PRODUCTS_DIR\}\/(Moya\/Moya\.framework\/|Alamofire\/Alamofire\.framework\/|Realm-library\/libRealm-library\.a\/))"#
+        let xcconfigReplacements = ["${PODS_CONFIGURATION_BUILD_DIR}/Realm-library": "${HOME}/.rugby/bin/Realm-library/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/d2d48c5", "${PODS_CONFIGURATION_BUILD_DIR}/Realm-library/Realm_library.modulemap": "${HOME}/.rugby/bin/Realm-library/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/d2d48c5/Realm_library.modulemap", "${PODS_CONFIGURATION_BUILD_DIR}/Alamofire": "${HOME}/.rugby/bin/Alamofire/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/36ff0bc", "${PODS_CONFIGURATION_BUILD_DIR}/Moya/Moya.modulemap": "${HOME}/.rugby/bin/Moya/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/badaa58/Moya.modulemap", "${PODS_CONFIGURATION_BUILD_DIR}/Moya": "${HOME}/.rugby/bin/Moya/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/badaa58", "${PODS_CONFIGURATION_BUILD_DIR}/Realm-library/libRealm-library.a/Headers": "${HOME}/.rugby/bin/Realm-library/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/d2d48c5/libRealm-library.a/Headers", "${PODS_CONFIGURATION_BUILD_DIR}/Alamofire/Alamofire.modulemap": "${HOME}/.rugby/bin/Alamofire/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/36ff0bc/Alamofire.modulemap", "${PODS_XCFRAMEWORKS_BUILD_DIR}/Realm-library": "${HOME}/.rugby/bin/Realm-library/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/d2d48c5/Realm-library", "${PODS_CONFIGURATION_BUILD_DIR}/Moya/Moya.framework/Headers": "${HOME}/.rugby/bin/Moya/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/badaa58/Moya.framework/Headers", "${PODS_CONFIGURATION_BUILD_DIR}/Alamofire/Alamofire.framework/Headers": "${HOME}/.rugby/bin/Alamofire/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/36ff0bc/Alamofire.framework/Headers", "${PODS_XCFRAMEWORKS_BUILD_DIR}/Realm-library/Headers": "${HOME}/.rugby/bin/Realm-library/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/d2d48c5/Realm-library/Headers"]
+        let xcconfigRegexPattern = #"(\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Moya\/Moya\.framework\/Headers|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Moya|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Moya\/Moya\.modulemap|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Alamofire\/Alamofire\.framework\/Headers|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Alamofire|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Alamofire\/Alamofire\.modulemap|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Realm-library\/libRealm-library\.a\/Headers|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Realm-library|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Realm-library\/Realm_library\.modulemap|\$\{PODS_XCFRAMEWORKS_BUILD_DIR\}\/Realm-library\/Headers|\$\{PODS_XCFRAMEWORKS_BUILD_DIR\}\/Realm-library)\b"#
+        let frameworkReplacements = ["${BUILT_PRODUCTS_DIR}/Moya/Moya.framework": "${HOME}/.rugby/bin/Moya/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/badaa58/Moya.framework", "${BUILT_PRODUCTS_DIR}/Realm-library/libRealm-library.a": "${HOME}/.rugby/bin/Realm-library/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/d2d48c5/libRealm-library.a", "${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework": "${HOME}/.rugby/bin/Alamofire/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/36ff0bc/Alamofire.framework"]
+        let frameworksRegexPattern = #"\$\{BUILT_PRODUCTS_DIR\}\/(Moya\/Moya\.framework|Alamofire\/Alamofire\.framework|Realm-library\/libRealm-library\.a)\b"#
+        let resourcesReplacements = ["${BUILT_PRODUCTS_DIR}/Realm-library/libRealm-library.a/": "${HOME}/.rugby/bin/Realm-library/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/d2d48c5/libRealm-library.a/", "${BUILT_PRODUCTS_DIR}/Moya/Moya.framework/": "${HOME}/.rugby/bin/Moya/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/badaa58/Moya.framework/", "${PODS_CONFIGURATION_BUILD_DIR}/LocalPod/LocalPodResources.bundle": "${HOME}/.rugby/bin/LocalPodResources/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/17da84b/LocalPodResources.bundle", "${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework/": "${HOME}/.rugby/bin/Alamofire/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/36ff0bc/Alamofire.framework/"]
+        let resourcesRegexPattern = #"(\$\{PODS_CONFIGURATION_BUILD_DIR\}\/(LocalPod\/LocalPodResources\.bundle)\b|\$\{BUILT_PRODUCTS_DIR\}\/(Moya\/Moya\.framework\/|Alamofire\/Alamofire\.framework\/|Realm-library\/libRealm-library\.a\/))"#
         // swiftlint:enable line_length
 
         // Act
@@ -91,52 +91,52 @@ extension SupportFilesPatcherTests {
 
 private extension SupportFilesPatcherTests {
     private var localPodXCConfigReplacements: [String: String] {
-        let prefixKey = "\"${PODS_CONFIGURATION_BUILD_DIR}/"
-        let prefixValue = "\"${HOME}/.rugby/bin/"
+        let prefixKey = "${PODS_CONFIGURATION_BUILD_DIR}/"
+        let prefixValue = "${HOME}/.rugby/bin/"
         let envs = "/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/"
         return [
-            "\(prefixKey)Alamofire\"":
-                "\(prefixValue)Alamofire\(envs)36ff0bc\"",
-            "\(prefixKey)Moya/Moya.modulemap\"":
-                "\(prefixValue)Moya\(envs)badaa58/Moya.modulemap\"",
-            "\(prefixKey)Alamofire/Alamofire.framework/Headers\"":
-                "\(prefixValue)Alamofire\(envs)36ff0bc/Alamofire.framework/Headers\"",
-            "\(prefixKey)Alamofire/Alamofire.modulemap\"":
-                "\(prefixValue)Alamofire\(envs)36ff0bc/Alamofire.modulemap\"",
-            "\(prefixKey)Moya/Moya.framework/Headers\"":
-                "\(prefixValue)Moya\(envs)badaa58/Moya.framework/Headers\"",
-            "\(prefixKey)Moya\"":
-                "\(prefixValue)Moya\(envs)badaa58\""
+            "\(prefixKey)Alamofire":
+                "\(prefixValue)Alamofire\(envs)36ff0bc",
+            "\(prefixKey)Moya/Moya.modulemap":
+                "\(prefixValue)Moya\(envs)badaa58/Moya.modulemap",
+            "\(prefixKey)Alamofire/Alamofire.framework/Headers":
+                "\(prefixValue)Alamofire\(envs)36ff0bc/Alamofire.framework/Headers",
+            "\(prefixKey)Alamofire/Alamofire.modulemap":
+                "\(prefixValue)Alamofire\(envs)36ff0bc/Alamofire.modulemap",
+            "\(prefixKey)Moya/Moya.framework/Headers":
+                "\(prefixValue)Moya\(envs)badaa58/Moya.framework/Headers",
+            "\(prefixKey)Moya":
+                "\(prefixValue)Moya\(envs)badaa58"
         ]
     }
 
     private var localPodXCConfigRegexPattern: String {
         // swiftlint:disable:next line_length
-        #""(\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Moya\/Moya\.framework\/Headers|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Moya|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Moya\/Moya\.modulemap|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Alamofire\/Alamofire\.framework\/Headers|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Alamofire|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Alamofire\/Alamofire\.modulemap)""#
+        #"(\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Moya\/Moya\.framework\/Headers|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Moya|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Moya\/Moya\.modulemap|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Alamofire\/Alamofire\.framework\/Headers|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Alamofire|\$\{PODS_CONFIGURATION_BUILD_DIR\}\/Alamofire\/Alamofire\.modulemap)\b"#
     }
 
     private var frameworkReplacements: [String: String] {
-        let prefixKey = "\"${BUILT_PRODUCTS_DIR}/"
-        let prefixValue = "\"${HOME}/.rugby/bin/"
+        let prefixKey = "${BUILT_PRODUCTS_DIR}/"
+        let prefixValue = "${HOME}/.rugby/bin/"
         let envs = "/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/"
         return [
-            "\(prefixKey)Alamofire/Alamofire.framework\"":
-                "\(prefixValue)Alamofire\(envs)36ff0bc/Alamofire.framework\"",
-            "\(prefixKey)Moya/Moya.framework\"":
-                "\(prefixValue)Moya\(envs)badaa58/Moya.framework\""
+            "\(prefixKey)Alamofire/Alamofire.framework":
+                "\(prefixValue)Alamofire\(envs)36ff0bc/Alamofire.framework",
+            "\(prefixKey)Moya/Moya.framework":
+                "\(prefixValue)Moya\(envs)badaa58/Moya.framework"
         ]
     }
 
     private var frameworksRegexPattern: String {
-        #""\$\{BUILT_PRODUCTS_DIR\}\/(Moya\/Moya\.framework|Alamofire\/Alamofire\.framework)""#
+        #"\$\{BUILT_PRODUCTS_DIR\}\/(Moya\/Moya\.framework|Alamofire\/Alamofire\.framework)\b"#
     }
 
     private var resourcesReplacements: [String: String] {
         let prefixValue = "${HOME}/.rugby/bin/"
         let envs = "/${CONFIGURATION}${EFFECTIVE_PLATFORM_NAME}-${ARCHS}/"
         return [
-            "\"${PODS_CONFIGURATION_BUILD_DIR}/LocalPod/LocalPodResources.bundle\"":
-                "\"\(prefixValue)LocalPodResources\(envs)17da84b/LocalPodResources.bundle\"",
+            "${PODS_CONFIGURATION_BUILD_DIR}/LocalPod/LocalPodResources.bundle":
+                "\(prefixValue)LocalPodResources\(envs)17da84b/LocalPodResources.bundle",
             "${BUILT_PRODUCTS_DIR}/Moya/Moya.framework/":
                 "\(prefixValue)Moya\(envs)badaa58/Moya.framework/",
             "${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework/":
@@ -146,7 +146,7 @@ private extension SupportFilesPatcherTests {
 
     private var resourcesRegexPattern: String {
         // swiftlint:disable:next line_length
-        #"("\$\{PODS_CONFIGURATION_BUILD_DIR\}\/(LocalPod\/LocalPodResources\.bundle)"|\$\{BUILT_PRODUCTS_DIR\}\/(Moya\/Moya\.framework\/|Alamofire\/Alamofire\.framework\/))"#
+        #"(\$\{PODS_CONFIGURATION_BUILD_DIR\}\/(LocalPod\/LocalPodResources\.bundle)\b|\$\{BUILT_PRODUCTS_DIR\}\/(Moya\/Moya\.framework\/|Alamofire\/Alamofire\.framework\/))"#
     }
 }
 


### PR DESCRIPTION
### Description
I updated the code to use '\b' for match endings, removing the initial boundary (as '\b' at the beginning didn't work). Tested successfully in my project and added relevant unit tests. Further testing may be required.

### References
https://github.com/swiftyfinch/Rugby/issues/271

### Checklist (I have ...)
- [x] 🧐 Followed the code style of the rest of the project
- [ ] 📖 Updated the documentation, if necessary
- [x] 👨🏻‍🔧 Added at least one test which validates that my change is working, if appropriate
- [x] 👮🏻‍♂️ Run `make lint` and fixed all warnings
- [x] ✅ Run `make test` and fixed all tests

❤️ Thanks for contributing to the 🏈 Rugby!
