### PR TITLE
Fix development pod hash affected by path change

### DIFF
--- a/Sources/RugbyFoundation/Core/Common/Hashers/FileContentHasher.swift
+++ b/Sources/RugbyFoundation/Core/Common/Hashers/FileContentHasher.swift
@@ -18,7 +18,7 @@ final class FileContentHasher {
 
     private func hashContext(path: String) throws -> String {
         let file = try File.at(path)
-        return try "\(relativePath(of: file)): \(hash(file))"
+        return try "\(path): \(hash(file))"
     }
 
     private func hash(_ file: IFile) throws -> String {

--- a/Sources/RugbyFoundation/XcodeProject/Extensions/XcodeProj/PBXFileElement/PBXFileElement+FullPath.swift
+++ b/Sources/RugbyFoundation/XcodeProject/Extensions/XcodeProj/PBXFileElement/PBXFileElement+FullPath.swift
@@ -2,6 +2,6 @@ import XcodeProj
 
 extension PBXFileElement {
     var fullPath: String? {
-        try? fullPath(sourceRoot: "Pods")
+        try? fullPath(sourceRoot: "Pods")?.string
     }
 }


### PR DESCRIPTION
### Description
This is a tricky fix now, I intercepted twice to make the path an absolute path. Obviously, this might cause issues in other scenarios. I hope we can find a solution that is compatible with various cases. Until then, I will use this branch to ensure the work can continue.

By the way, since we are using a mono repo, the relative paths for development pods are consistent, so the value of `PODS_TARGET_SRCROOT` remains constant. Therefore, when `:path` in Podfile changes, this value itself will also affect the result of the hash.

### References
https://github.com/swiftyfinch/Rugby/issues/279

### Checklist (I have ...)
- [ ] 🧐 Followed the code style of the rest of the project
- [ ] 📖 Updated the documentation, if necessary
- [ ] 👨🏻‍🔧 Added at least one test which validates that my change is working, if appropriate
- [ ] 👮🏻‍♂️ Run `make lint` and fixed all warnings
- [ ] ✅ Run `make test` and fixed all tests

❤️ Thanks for contributing to the 🏈 Rugby!
