### PR TITLE
⚙️ Add separate `.swiftlint` file to tests

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -109,8 +109,7 @@ jobs:
 
     - name: Rugby
       working-directory: ./Example
-      run: |
-        rugby --prebuild --targets Pods-ExampleFrameworks --output multiline
+      run: rugby --prebuild --targets Pods-ExampleFrameworks --output multiline
 
     - run: brew install xcbeautify
     - name: XcodeBuild Test
@@ -148,9 +147,7 @@ jobs:
 
     - name: Rugby
       working-directory: ./Example
-      run: |
-        rugby build -t Pods-ExampleLibs --output multiline
-        rugby use -t Pods-ExampleLibs --output multiline
+      run: rugby --prebuild --targets Pods-ExampleLibs --output multiline
 
     - run: brew install xcbeautify
     - name: XcodeBuild Test

--- a/Tests/.swiftlint.yml
+++ b/Tests/.swiftlint.yml
@@ -1,0 +1,9 @@
+disabled_rules:
+  - let_var_whitespace
+  - conditional_returns_on_newline
+  - todo
+  - reduce_boolean
+  - attributes
+  - function_body_length
+  - identifier_name
+  - large_tuple

--- a/Tests/FoundationTests/Core/Build/LibrariesPatcherTests.swift
+++ b/Tests/FoundationTests/Core/Build/LibrariesPatcherTests.swift
@@ -28,7 +28,6 @@ final class LibrariesPatcherTests: XCTestCase {
 }
 
 extension LibrariesPatcherTests {
-    // swiftlint:disable:next function_body_length
     func test_basic() async throws {
         let fileMock = IFileMock()
         fileMock.readReturnValue = """

--- a/Tests/FoundationTests/Core/Build/PrebuildManagerTests.swift
+++ b/Tests/FoundationTests/Core/Build/PrebuildManagerTests.swift
@@ -62,7 +62,6 @@ extension PrebuildManagerTests {
 extension PrebuildManagerTests {
     func test_zeroTargets() async throws {
         var logReceivedInvocations: [
-            // swiftlint:disable:next large_tuple
             (header: String, footer: String?, metricKey: String?, level: LogLevel, output: LoggerOutput)
         ] = []
         logger.logFooterMetricKeyLevelOutputBlockClosure = { header, footer, metricKey, level, output, block in

--- a/Tests/FoundationTests/Core/Build/XcodeBuild/BuildLogFormatterTests.swift
+++ b/Tests/FoundationTests/Core/Build/XcodeBuild/BuildLogFormatterTests.swift
@@ -4,7 +4,6 @@ import XcbeautifyLib
 import XCTest
 
 // swiftlint:disable line_length
-// swiftlint:disable function_body_length
 // swiftlint:disable file_length
 
 final class BuildLogFormatterTests: XCTestCase {
@@ -431,5 +430,4 @@ extension BuildLogFormatterTests {
 }
 
 // swiftlint:enable line_length
-// swiftlint:enable function_body_length
 // swiftlint:enable file_length

--- a/Tests/FoundationTests/Core/Build/XcodeBuild/XcodeBuildExecutorTests.swift
+++ b/Tests/FoundationTests/Core/Build/XcodeBuild/XcodeBuildExecutorTests.swift
@@ -2,7 +2,7 @@ import Fish
 @testable import RugbyFoundation
 import XCTest
 
-// swiftlint:disable function_body_length identifier_name
+// swiftlint:disable identifier_name
 
 final class XcodeBuildExecutorTests: XCTestCase {
     private var sut: XcodeBuildExecutor!
@@ -172,4 +172,4 @@ extension XcodeBuildExecutorTests {
     }
 }
 
-// swiftlint:enable function_body_length identifier_name
+// swiftlint:enable identifier_name


### PR DESCRIPTION
### Description
<!--Please describe your pull request.-->
I've added a separate `.swiftlint` file to **Tests** folder to use more lenient rules in tests. 

### References
<!--Provide links to an existing issue or external references/discussions, if appropriate.-->
- https://github.com/realm/SwiftLint#using-multiple-configuration-files

### Checklist (I have ...)
- [x] 🧐 Followed the code style of the rest of the project
- [ ] 📖 Updated the documentation, if necessary
- [ ] 👨🏻‍🔧 Added at least one test which validates that my change is working, if appropriate
- [x] 👮🏻‍♂️ Run `make lint` and fixed all warnings
- [x] ✅ Run `make test` and fixed all tests

❤️ Thanks for contributing to the 🏈 Rugby!
