### PR TITLE
⚙️ Keep `--result-bundle-path` only in `full build` and `cache` commands

### DIFF
--- a/Docs/commands-help/build/full.md
+++ b/Docs/commands-help/build/full.md
@@ -24,8 +24,8 @@
 ╰────────────────────────────────────────────────────────────────────────────────╯
  Flags:
 ╭──────────────────────────────────────────────────╮
-│ --ignore-cache    * Ignore shared cache.         │
 │ --strip           * Build without debug symbols. │
+│ --ignore-cache    * Ignore shared cache.         │
 │ -v, --verbose []  * Increase verbosity level.    │
 │ -q, --quiet []    * Decrease verbosity level.    │
 │ -h, --help        * Show help information.       │

--- a/Docs/commands-help/build/full.md
+++ b/Docs/commands-help/build/full.md
@@ -15,11 +15,11 @@
 │ -s, --sdk                  * Build SDK: sim or ios.                            │
 │ -a, --arch                 * Build architecture: auto, x86_64 or arm64.        │
 │ -c, --config               * Build configuration. (Debug)                      │
-│ --result-bundle-path       * Path for xcresult bundle.                         │
 │ -t, --targets []           * Targets for building. Empty means all targets.    │
 │ -g, --targets-as-regex []  * Targets for building as a RegEx pattern.          │
 │ -e, --except []            * Exclude targets from building.                    │
 │ -x, --except-as-regex []   * Exclude targets from building as a RegEx pattern. │
+│ --result-bundle-path       * Path to xcresult bundle.                          │
 │ -o, --output               * Output mode: fold, multiline, silent, raw.        │
 ╰────────────────────────────────────────────────────────────────────────────────╯
  Flags:

--- a/Docs/commands-help/build/pre.md
+++ b/Docs/commands-help/build/pre.md
@@ -15,7 +15,6 @@
 │ -s, --sdk                  * Build SDK: sim or ios.                            │
 │ -a, --arch                 * Build architecture: auto, x86_64 or arm64.        │
 │ -c, --config               * Build configuration. (Debug)                      │
-│ --result-bundle-path       * Path for xcresult bundle.                         │
 │ -t, --targets []           * Targets for building. Empty means all targets.    │
 │ -g, --targets-as-regex []  * Targets for building as a RegEx pattern.          │
 │ -e, --except []            * Exclude targets from building.                    │

--- a/Docs/commands-help/shortcuts/cache.md
+++ b/Docs/commands-help/shortcuts/cache.md
@@ -12,26 +12,26 @@
 
  Options:
 ╭────────────────────────────────────────────────────────────────────────────────╮
+│ --warmup                   * Warmup cache with this endpoint.                  │
 │ -s, --sdk                  * Build SDK: sim or ios.                            │
 │ -a, --arch                 * Build architecture: auto, x86_64 or arm64.        │
 │ -c, --config               * Build configuration. (Debug)                      │
-│ --result-bundle-path       * Path for xcresult bundle.                         │
 │ -t, --targets []           * Targets for building. Empty means all targets.    │
 │ -g, --targets-as-regex []  * Targets for building as a RegEx pattern.          │
 │ -e, --except []            * Exclude targets from building.                    │
 │ -x, --except-as-regex []   * Exclude targets from building as a RegEx pattern. │
+│ --result-bundle-path       * Path to xcresult bundle.                          │
 │ -o, --output               * Output mode: fold, multiline, silent, raw.        │
-│ --warmup                   * Warmup cache with this endpoint.                  │
 ╰────────────────────────────────────────────────────────────────────────────────╯
  Flags:
 ╭─────────────────────────────────────────────────────────────────────────╮
+│ -r, --rollback    * Restore projects state before the last Rugby usage. │
+│ --prebuild        * Prebuild targets ignoring sources.                  │
+│ --strip           * Build without debug symbols.                        │
 │ --ignore-cache    * Ignore shared cache.                                │
 │ --delete-sources  * Delete target groups from project.                  │
-│ -r, --rollback    * Restore projects state before the last Rugby usage. │
-│ --strip           * Build without debug symbols.                        │
 │ -v, --verbose []  * Increase verbosity level.                           │
 │ -q, --quiet []    * Decrease verbosity level.                           │
-│ --prebuild        * Prebuild targets ignoring sources.                  │
 │ -h, --help        * Show help information.                              │
 ╰─────────────────────────────────────────────────────────────────────────╯
 ```

--- a/Docs/commands-help/use.md
+++ b/Docs/commands-help/use.md
@@ -16,7 +16,6 @@
 │ -g, --targets-as-regex []  * Targets for building as a RegEx pattern.          │
 │ -e, --except []            * Exclude targets from building.                    │
 │ -x, --except-as-regex []   * Exclude targets from building as a RegEx pattern. │
-│ --result-bundle-path       * Path for xcresult bundle.                         │
 │ -o, --output               * Output mode: fold, multiline, silent, raw.        │
 ╰────────────────────────────────────────────────────────────────────────────────╯
  Flags:

--- a/Docs/commands-help/warmup.md
+++ b/Docs/commands-help/warmup.md
@@ -19,7 +19,6 @@
 │ -s, --sdk                  * Build SDK: sim or ios.                               │
 │ -a, --arch                 * Build architecture: auto, x86_64 or arm64.           │
 │ -c, --config               * Build configuration. (Debug)                         │
-│ --result-bundle-path       * Path for xcresult bundle.                            │
 │ -t, --targets []           * Targets for building. Empty means all targets.       │
 │ -g, --targets-as-regex []  * Targets for building as a RegEx pattern.             │
 │ -e, --except []            * Exclude targets from building.                       │

--- a/Sources/Rugby/Commands/Basic/Build/AdditionalBuildOptions.swift
+++ b/Sources/Rugby/Commands/Basic/Build/AdditionalBuildOptions.swift
@@ -3,7 +3,4 @@ import ArgumentParser
 struct AdditionalBuildOptions: ParsableCommand {
     @Flag(name: .long, help: "Build without debug symbols.")
     var strip = false
-
-    @Option(name: .long, help: "Path for xcresult bundle.")
-    var resultBundlePath: String?
 }

--- a/Sources/Rugby/Commands/Basic/Build/Build.swift
+++ b/Sources/Rugby/Commands/Basic/Build/Build.swift
@@ -22,11 +22,14 @@ extension Build {
             discussion: Links.commandsHelp("build/full.md")
         )
 
+        @OptionGroup
+        var buildOptions: BuildOptions
+
         @Flag(name: .long, help: "Ignore shared cache.")
         var ignoreCache = false
 
-        @OptionGroup
-        var buildOptions: BuildOptions
+        @Option(name: .long, help: "Path to xcresult bundle.")
+        var resultBundlePath: String?
 
         @OptionGroup
         var commonOptions: CommonOptions
@@ -48,7 +51,7 @@ extension Build {
                     patterns: buildOptions.targetsOptions.exceptAsRegex,
                     exactMatches: buildOptions.targetsOptions.exceptTargets
                 ),
-                options: buildOptions.xcodeBuildOptions(),
+                options: buildOptions.xcodeBuildOptions(resultBundlePath: resultBundlePath),
                 paths: dependencies.xcode.paths(),
                 ignoreCache: ignoreCache
             )

--- a/Sources/Rugby/Commands/Basic/Build/BuildOptions.swift
+++ b/Sources/Rugby/Commands/Basic/Build/BuildOptions.swift
@@ -20,7 +20,10 @@ struct BuildOptions: AsyncParsableCommand {
     @OptionGroup
     var targetsOptions: TargetsOptions
 
-    func xcodeBuildOptions(skipSigning: Bool = false) -> XcodeBuildOptions {
+    func xcodeBuildOptions(
+        skipSigning: Bool = false,
+        resultBundlePath: String? = nil
+    ) -> XcodeBuildOptions {
         XcodeBuildOptions(
             sdk: sdk,
             config: config,
@@ -29,7 +32,7 @@ struct BuildOptions: AsyncParsableCommand {
                 strip: additionalBuildOptions.strip,
                 skipSigning: skipSigning
             ),
-            resultBundlePath: additionalBuildOptions.resultBundlePath
+            resultBundlePath: resultBundlePath
         )
     }
 

--- a/Sources/Rugby/Commands/Mixed/Shortcuts.swift
+++ b/Sources/Rugby/Commands/Mixed/Shortcuts.swift
@@ -63,26 +63,29 @@ extension Shortcuts {
             discussion: Links.commandsHelp("shortcuts/cache.md")
         )
 
-        @Flag(name: .long, help: "Ignore shared cache.")
-        var ignoreCache = false
-
-        @Flag(name: .long, help: "Delete target groups from project.")
-        var deleteSources = false
-
         @Flag(name: .shortAndLong, help: "Restore projects state before the last Rugby usage.")
         var rollback = false
 
-        @OptionGroup
-        var buildOptions: BuildOptions
-
-        @OptionGroup
-        var commonOptions: CommonOptions
+        @Flag(name: .long, help: "Prebuild targets ignoring sources.")
+        var prebuild = false
 
         @Option(help: "Warmup cache with this endpoint.")
         var warmup: String?
 
-        @Flag(name: .long, help: "Prebuild targets ignoring sources.")
-        var prebuild = false
+        @OptionGroup
+        var buildOptions: BuildOptions
+
+        @Flag(name: .long, help: "Ignore shared cache.")
+        var ignoreCache = false
+
+        @Option(name: .long, help: "Path to xcresult bundle.")
+        var resultBundlePath: String?
+
+        @Flag(name: .long, help: "Delete target groups from project.")
+        var deleteSources = false
+
+        @OptionGroup
+        var commonOptions: CommonOptions
 
         func run() async throws {
             try await run(body,
@@ -123,6 +126,7 @@ extension Shortcuts.Cache: RunnableCommand {
         var build = Build.Full()
         build.buildOptions = buildOptions
         build.ignoreCache = ignoreCache
+        build.resultBundlePath = resultBundlePath
         build.commonOptions = commonOptions
         runnableCommands.append(("Build", build))
 

--- a/Tests/.swiftlint.yml
+++ b/Tests/.swiftlint.yml
@@ -1,9 +1,4 @@
 disabled_rules:
-  - let_var_whitespace
-  - conditional_returns_on_newline
-  - todo
-  - reduce_boolean
-  - attributes
   - function_body_length
   - identifier_name
   - large_tuple


### PR DESCRIPTION
### Description
<!--Please describe your pull request.-->
I've kept `--result-bundle-path` only in full build and cache commands.
This option is passed to `xcodebuild` which is used only in these commands.

### References
<!--Provide links to an existing issue or external references/discussions, if appropriate.-->
- None

### Checklist (I have ...)
- [x] 🧐 Followed the code style of the rest of the project
- [x] 📖 Updated the documentation, if necessary
- [ ] 👨🏻‍🔧 Added at least one test which validates that my change is working, if appropriate
- [x] 👮🏻‍♂️ Run `make lint` and fixed all warnings
- [x] ✅ Run `make test` and fixed all tests

❤️ Thanks for contributing to the 🏈 Rugby!
