### PR TITLE
🐛 Fixed relative paths in file hasher when they even outside of `$PWD` parent

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftyfinch/Fish",
       "state" : {
-        "revision" : "78b0685ff956af62ee6c2eb20ff3751c14e16d13",
-        "version" : "0.1.0"
+        "revision" : "cb55bf4dc0fa0b74b7c64da66df5a4be834e884d",
+        "version" : "0.1.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .package(url: "https://github.com/tuist/xcbeautify", from: "1.0.0"),
         .package(url: "https://github.com/jpsim/Yams", from: "5.0.6"),
         .package(url: "https://github.com/marmelroy/Zip", from: "2.1.2"),
-        .package(url: "https://github.com/swiftyfinch/Fish", from: "0.1.0")
+        .package(url: "https://github.com/swiftyfinch/Fish", from: "0.1.1")
     ],
     targets: [
         // rugby

--- a/Sources/RugbyFoundation/Core/Common/Hashers/FileContentHasher.swift
+++ b/Sources/RugbyFoundation/Core/Common/Hashers/FileContentHasher.swift
@@ -39,11 +39,13 @@ final class FileContentHasher {
         }
     }
 
+    // Traversing from working directory to its parents to find nearest common parent.
     private func relativePath(of file: IFile) -> String {
-        let relativePath = file.relativePath(to: workingDirectory)
-        // Sometimes modules can be outside of working directory (React Native).
-        if relativePath.hasPrefix("/"), let parent = workingDirectory.parent {
-            return file.relativePath(to: parent)
+        var relativePath = file.path
+        var current: IFolder? = workingDirectory
+        while relativePath == file.path, let toFolder = current {
+            relativePath = file.relativePath(to: toFolder)
+            current = toFolder.parent
         }
         return relativePath
     }


### PR DESCRIPTION
### Description
<!--Please describe your pull request.-->
Sometimes modules can be outside of working directory.
We need to find nearest common parent to convert paths to relative ones during hash process.
Read more in the issue reference.

### References
<!--Provide links to an existing issue or external references/discussions, if appropriate.-->
- #258 
- #279 

### Checklist (I have ...)
- [x] 🧐 Followed the code style of the rest of the project
- [ ] 📖 Updated the documentation, if necessary
- [x] 👨🏻‍🔧 Added at least one test which validates that my change is working, if appropriate
- [x] 👮🏻‍♂️ Run `make lint` and fixed all warnings
- [x] ✅ Run `make test` and fixed all tests

❤️ Thanks for contributing to the 🏈 Rugby!
