### PR TITLE
🐛 Fix bug when target name has plus sign

### DIFF
--- a/Sources/Rugby/Utils/Regex/Regex.swift
+++ b/Sources/Rugby/Utils/Regex/Regex.swift
@@ -3,7 +3,7 @@ import RugbyFoundation
 
 func regex(patterns: [String], exactMatches: [String]) throws -> NSRegularExpression? {
     guard !patterns.isEmpty || !exactMatches.isEmpty else { return nil }
-    let exactMatches = exactMatches.map { "^\($0)$" }
+    let exactMatches = exactMatches.map { "^\(NSRegularExpression.escapedPattern(for: $0))$" }
     let joinedStrings = (patterns + exactMatches).joined(separator: "|")
     let regexString = "(" + joinedStrings + ")"
     return try NSRegularExpression(pattern: regexString, options: .anchorsMatchLines)

--- a/Tests/RugbyTests/Utils/Regex/RegexTests.swift
+++ b/Tests/RugbyTests/Utils/Regex/RegexTests.swift
@@ -1,0 +1,38 @@
+@testable import Rugby
+import RugbyFoundation
+import XCTest
+
+final class RegexTests: XCTestCase {
+    func test_plusSignEscaping_exactMatches() throws {
+        let regex = try regex(patterns: [], exactMatches: ["Keyboard+LayoutGuide-framework"])
+
+        // Assert
+        let unwrapedRegex = try XCTUnwrap(regex)
+        XCTAssertTrue(unwrapedRegex.isMatched("Keyboard+LayoutGuide-framework"))
+    }
+
+    func test_plusSignEscaping_patterns() throws {
+        let regex = try regex(patterns: ["Keyboard.*"], exactMatches: [])
+
+        // Assert
+        let unwrapedRegex = try XCTUnwrap(regex)
+        XCTAssertTrue(unwrapedRegex.isMatched("Keyboard+LayoutGuide-framework"))
+    }
+
+    func test_plusSignEscaping_patterns2() throws {
+        let regex = try regex(patterns: ["Keyboard\\+"], exactMatches: [])
+
+        // Assert
+        let unwrapedRegex = try XCTUnwrap(regex)
+        XCTAssertTrue(unwrapedRegex.isMatched("Keyboard+LayoutGuide-framework"))
+    }
+}
+
+// MARK: - Utils
+
+private extension NSRegularExpression {
+    func isMatched(_ string: String) -> Bool {
+        let range = NSRange(string.startIndex..., in: string)
+        return firstMatch(in: string, range: range) != nil
+    }
+}


### PR DESCRIPTION
### Description
<!--Please describe your pull request.-->
I've fixed an issue when a target name has a plus sign.
For example, `Keyboard+LayoutGuide-framework`.
```sh
> rugby cache -t Keyboard+LayoutGuide-framework
```

### References
<!--Provide links to an existing issue or external references/discussions, if appropriate.-->
- None

### Checklist (I have ...)
- [x] 🧐 Followed the code style of the rest of the project
- [ ] 📖 Updated the documentation, if necessary
- [x] 👨🏻‍🔧 Added at least one test which validates that my change is working, if appropriate
- [x] 👮🏻‍♂️ Run `make lint` and fixed all warnings
- [x] ✅ Run `make test` and fixed all tests

❤️ Thanks for contributing to the 🏈 Rugby!
