### PR TITLE
Providing correct help information for TargetsOptions

### DIFF
--- a/Docs/commands-help/delete.md
+++ b/Docs/commands-help/delete.md
@@ -13,10 +13,10 @@
  Options:
 ╭────────────────────────────────────────────────────────────────────────────────╮
 │ -p, --path                 * Project location. (Pods/Pods.xcodeproj)           │
-│ -t, --targets []           * Targets for building. Empty means all targets.    │
-│ -g, --targets-as-regex []  * Targets for building as a RegEx pattern.          │
-│ -e, --except []            * Exclude targets from building.                    │
-│ -x, --except-as-regex []   * Exclude targets from building as a RegEx pattern. │
+│ -t, --targets []           * Targets for deleting. Empty means all targets.    │
+│ -g, --targets-as-regex []  * Targets for deleting as a RegEx pattern.          │
+│ -e, --except []            * Exclude targets from deleting.                    │
+│ -x, --except-as-regex []   * Exclude targets from deleting as a RegEx pattern. │
 │ -o, --output               * Output mode: fold, multiline, silent, raw.        │
 ╰────────────────────────────────────────────────────────────────────────────────╯
  Flags:

--- a/Docs/commands-help/use.md
+++ b/Docs/commands-help/use.md
@@ -12,10 +12,10 @@
 
  Options:
 ╭────────────────────────────────────────────────────────────────────────────────╮
-│ -t, --targets []           * Targets for building. Empty means all targets.    │
-│ -g, --targets-as-regex []  * Targets for building as a RegEx pattern.          │
-│ -e, --except []            * Exclude targets from building.                    │
-│ -x, --except-as-regex []   * Exclude targets from building as a RegEx pattern. │
+│ -t, --targets []           * Targets for using. Empty means all targets.       │
+│ -g, --targets-as-regex []  * Targets for using as a RegEx pattern.             │
+│ -e, --except []            * Exclude targets from using.                       │
+│ -x, --except-as-regex []   * Exclude targets from using as a RegEx pattern.    │
 │ -o, --output               * Output mode: fold, multiline, silent, raw.        │
 ╰────────────────────────────────────────────────────────────────────────────────╯
  Flags:

--- a/Sources/Rugby/Commands/Basic/Build/BuildOptions.swift
+++ b/Sources/Rugby/Commands/Basic/Build/BuildOptions.swift
@@ -18,7 +18,7 @@ struct BuildOptions: AsyncParsableCommand {
     var additionalBuildOptions: AdditionalBuildOptions
 
     @OptionGroup
-    var targetsOptions: TargetsOptions
+    var targetsOptions: TargetsOptions<TargetsOptionsNameSpace.Building>
 
     func xcodeBuildOptions(
         skipSigning: Bool = false,

--- a/Sources/Rugby/Commands/Basic/Build/TargetsOptions.swift
+++ b/Sources/Rugby/Commands/Basic/Build/TargetsOptions.swift
@@ -1,19 +1,66 @@
 import ArgumentParser
 
-struct TargetsOptions: ParsableCommand {
-    @Option(name: .shortAndLong, parsing: .upToNextOption, help: "Targets for building. Empty means all targets.")
+/// Namespace for providing correct help information based on type
+enum TargetsOptionsNameSpace {
+    enum Deleting {}
+    enum Building {}
+    enum Using {}
+}
+
+struct TargetsOptions<T>: ParsableCommand {
+    @Option(name: .shortAndLong, parsing: .upToNextOption, help: Self.targetsHelp)
     var targets: [String] = []
 
     @Option(name: [.long, .customShort("g")],
             parsing: .upToNextOption,
-            help: "Targets for building as a RegEx pattern.")
+            help: Self.targetsAsRegexHelp)
     var targetsAsRegex: [String] = []
 
-    @Option(name: [.customLong("except"), .short], parsing: .upToNextOption, help: "Exclude targets from building.")
+    @Option(name: [.customLong("except"), .short], parsing: .upToNextOption, help: Self.exceptTargetsHelp)
     var exceptTargets: [String] = []
 
     @Option(name: [.long, .customShort("x")],
             parsing: .upToNextOption,
-            help: "Exclude targets from building as a RegEx pattern.")
+            help: Self.exceptAsRegexHelp)
     var exceptAsRegex: [String] = []
+}
+
+extension TargetsOptions {
+    static var command: String {
+        switch T.self {
+        case is TargetsOptionsNameSpace.Deleting.Type:
+            return "deleting"
+        case is TargetsOptionsNameSpace.Using.Type:
+            return "using"
+        default:
+            return "building"
+        }
+    }
+
+    func mapTo<U>(type _: U.Type) -> TargetsOptions<U> {
+        TargetsOptions<U>(
+            targets: targets,
+            targetsAsRegex: targetsAsRegex,
+            exceptTargets: exceptTargets,
+            exceptAsRegex: exceptAsRegex
+        )
+    }
+}
+
+extension TargetsOptions {
+    static var targetsHelp: ArgumentHelp {
+        "Targets for building. Empty means all targets."
+    }
+
+    static var targetsAsRegexHelp: ArgumentHelp {
+        "Targets for \(command) as a RegEx pattern."
+    }
+
+    static var exceptTargetsHelp: ArgumentHelp {
+        "Exclude targets from \(command)."
+    }
+
+    static var exceptAsRegexHelp: ArgumentHelp {
+        "Exclude targets from \(command) as a RegEx pattern."
+    }
 }

--- a/Sources/Rugby/Commands/Basic/Delete.swift
+++ b/Sources/Rugby/Commands/Basic/Delete.swift
@@ -19,7 +19,7 @@ struct Delete: AsyncParsableCommand {
     var deleteSources = false
 
     @OptionGroup
-    var targetsOptions: TargetsOptions
+    var targetsOptions: TargetsOptions<TargetsOptionsNameSpace.Deleting>
 
     @OptionGroup
     var commonOptions: CommonOptions

--- a/Sources/Rugby/Commands/Basic/Use.swift
+++ b/Sources/Rugby/Commands/Basic/Use.swift
@@ -13,7 +13,7 @@ struct Use: AsyncParsableCommand {
     var deleteSources = false
 
     @OptionGroup
-    var targetsOptions: TargetsOptions
+    var targetsOptions: TargetsOptions<TargetsOptionsNameSpace.Using>
 
     @OptionGroup
     var additionalBuildOptions: AdditionalBuildOptions

--- a/Sources/Rugby/Commands/Mixed/Shortcuts.swift
+++ b/Sources/Rugby/Commands/Mixed/Shortcuts.swift
@@ -132,7 +132,7 @@ extension Shortcuts.Cache: RunnableCommand {
 
         var use = Use()
         use.deleteSources = deleteSources
-        use.targetsOptions = buildOptions.targetsOptions
+        use.targetsOptions = buildOptions.targetsOptions.mapTo(type: TargetsOptionsNameSpace.Using.self)
         use.additionalBuildOptions = buildOptions.additionalBuildOptions
         use.commonOptions = commonOptions
         runnableCommands.append(("Use", use))


### PR DESCRIPTION
### Description

> The problem: if you are to call `$ rugby delete -h` as a result you will get misleading help documentation.

I've managed to replace help **documentation** for delete/use commands.
The code itself is not the best i.e cause of property wrapper limitations had to use some hacks like generic types.
If you have any ideas how to make it better please suggest some :)
**IF you're willing** to accept the pr, i'll write unit tests.

Thanks for checking out!

<img width="500" alt="Screenshot 2023-12-22 at 17 33 59" src="https://github.com/swiftyfinch/Rugby/assets/36343782/5cdc4c40-485b-4566-a6b8-eafa20886e99">


### Checklist (I have ...)
- [x] 🧐 Followed the code style of the rest of the project
- [x] 📖 Updated the documentation, if necessary
- [ ] 👨🏻‍🔧 Added at least one test which validates that my change is working, if appropriate
- [x] 👮🏻‍♂️ Run `make lint` and fixed all warnings
- [x] ✅ Run `make test` and fixed all tests

❤️ Thanks for contributing to the 🏈 Rugby!
