### PR TITLE
🐛 Fixed concurrent crash on target delete

### DIFF
--- a/Sources/RugbyFoundation/XcodeProject/Services/XcodeTargetsEditor.swift
+++ b/Sources/RugbyFoundation/XcodeProject/Services/XcodeTargetsEditor.swift
@@ -47,7 +47,7 @@ final class XcodeTargetsEditor: Loggable {
 
         // Remove all dependencies with these targets
         let targets = try await targetsDataSource.targets.subtracting(targetsForRemove)
-        try targets.values.compactMap { target in
+        try targets.values.forEach { target in
             // Add sub-dependencies of removing dependency explicitly
             let dependencies = target.explicitDependencies.keysIntersection(targetsForRemove)
             guard dependencies.isNotEmpty else { return }

--- a/Sources/RugbyFoundation/XcodeProject/Services/XcodeTargetsEditor.swift
+++ b/Sources/RugbyFoundation/XcodeProject/Services/XcodeTargetsEditor.swift
@@ -47,7 +47,7 @@ final class XcodeTargetsEditor: Loggable {
 
         // Remove all dependencies with these targets
         let targets = try await targetsDataSource.targets.subtracting(targetsForRemove)
-        try await targets.values.concurrentCompactMap { target in
+        try targets.values.compactMap { target in
             // Add sub-dependencies of removing dependency explicitly
             let dependencies = target.explicitDependencies.keysIntersection(targetsForRemove)
             guard dependencies.isNotEmpty else { return }


### PR DESCRIPTION
### Description

We discovered a crash in rugby when the application has a very large number of targets that need to be deleted. The crash occurs due to asynchronous removal of targets. In the merge request I made this deletion synchronous

### References

```
Thread 10 Crashed:
0   libsystem_kernel.dylib        	    0x7ff815a891e2 __pthread_kill + 10
1   libsystem_pthread.dylib       	    0x7ff815ac0ee6 pthread_kill + 263
2   libsystem_c.dylib             	    0x7ff8159e7b45 abort + 123
3   libsystem_malloc.dylib        	    0x7ff8158fe752 malloc_vreport + 888
4   libsystem_malloc.dylib        	    0x7ff815913a08 malloc_zone_error + 183
5   libswiftCore.dylib            	    0x7ff8253b9290 _swift_release_dealloc + 16
6   libswiftCore.dylib            	    0x7ff8253b9dab bool swift::RefCounts<swift::RefCountBitsT<(swift::RefCountInlinedness)1>>::doDecrementSlow<(swift::PerformDeinit)1>(swift::RefCountBitsT<(swift::RefCountInlinedness)1>, unsigned int) + 139
7   libswiftCore.dylib            	    0x7ff8253acedb swift_arrayDestroy + 59
8   libswiftCore.dylib            	    0x7ff82513affa _ContiguousArrayStorage.__deallocating_deinit + 42
9   libswiftCore.dylib            	    0x7ff8253b9290 _swift_release_dealloc + 16
10  libswiftCore.dylib            	    0x7ff8253b9dab bool swift::RefCounts<swift::RefCountBitsT<(swift::RefCountInlinedness)1>>::doDecrementSlow<(swift::PerformDeinit)1>(swift::RefCountBitsT<(swift::RefCountInlinedness)1>, unsigned int) + 139
11  rugby                         	       0x10707f2e7 PBXProj.addDependency(_:toTarget:) + 1927
12  rugby                         	       0x1070ac1fd specialized Sequence.forEach(_:) + 413
13  rugby                         	       0x1070a4dee closure #1 in closure #1 in XcodeTargetsEditor.deleteTargets(_:keepGroups:) + 270
14  rugby                         	       0x1070ac3e7 specialized Sequence.forEach(_:) + 391
15  rugby                         	       0x1070a4968 closure #1 in XcodeTargetsEditor.deleteTargets(_:keepGroups:) + 200
16  rugby                         	       0x1070ac011 partial apply for closure #1 in XcodeTargetsEditor.deleteTargets(_:keepGroups:) + 1
17  rugby                         	       0x1070944d1 specialized closure #1 in closure #1 in Collection.concurrentMap<A>(maxInParallel:_:) + 1
18  rugby                         	       0x107096a81 partial apply for specialized closure #1 in closure #1 in Collection.concurrentMap<A>(maxInParallel:_:) + 1

```


### Checklist (I have ...)
- [x] 🧐 Followed the code style of the rest of the project
- [ ] 📖 Updated the documentation, if necessary
- [ ] 👨🏻‍🔧 Added at least one test which validates that my change is working, if appropriate
- [x] 👮🏻‍♂️ Run `make lint` and fixed all warnings
- [x] ✅ Run `make test` and fixed all tests

❤️ Thanks for contributing to the 🏈 Rugby!
