### PR TITLE
⚙️ Fix GitHub actions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   swiftformat:
     name: SwiftFormat
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
     - uses: actions/checkout@v4
     - run: swiftformat . --lint --quiet --reporter github-actions-log

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,21 +12,21 @@ jobs:
     name: SwiftFormat
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run: swiftformat . --lint --quiet --reporter github-actions-log
 
   swiftlint:
     name: SwiftLint
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run: swiftlint --strict --quiet --reporter github-actions-logging
 
   install:
     name: Install Script
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install Rugby
       run: |
         curl -Ls curl -Ls https://swiftyfinch.github.io/rugby/install.sh | bash
@@ -37,8 +37,8 @@ jobs:
     name: Build Binary
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/cache@v3
+    - uses: actions/checkout@v4
+    - uses: actions/cache@v4
       with:
         path: .build
         key: ${{ runner.os }}-spm-${{ hashFiles('Package.resolved') }}
@@ -55,9 +55,9 @@ jobs:
       PROFDATA_FOLDER: .build/debug/codecov/default.profdata
       IGNORE_FILENAME_REGEX: .build|Tests
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run: brew install xcbeautify
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: .build
         key: ${{ runner.os }}-spm-${{ hashFiles('Package.resolved') }}
@@ -73,7 +73,7 @@ jobs:
           -format="lcov" \
           --use-color
     - name: Upload coverage reports to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
@@ -82,7 +82,7 @@ jobs:
         RUGBY_PATH=`swift build --show-bin-path`/rugby
         strip -rSTx $RUGBY_PATH
         echo "RUGBY_PATH=$RUGBY_PATH" >> $GITHUB_ENV
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: rugby
         path: ${{ env.RUGBY_PATH }}
@@ -92,13 +92,13 @@ jobs:
     needs: tests
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/download-artifact@v3
+    - uses: actions/checkout@v4
+    - uses: actions/download-artifact@v4
       with: { name: rugby }
     - run: chmod +x rugby && echo `pwd` >> $GITHUB_PATH
     - run: rugby --version
 
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: Example/Pods
         key: ${{ runner.os }}-pods-${{ hashFiles('Example/Podfile.lock') }}
@@ -130,13 +130,13 @@ jobs:
     needs: tests
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/download-artifact@v3
+    - uses: actions/checkout@v4
+    - uses: actions/download-artifact@v4
       with: { name: rugby }
     - run: chmod +x rugby && echo `pwd` >> $GITHUB_PATH
     - run: rugby --version
     
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: Example/Pods
         key: ${{ runner.os }}-pods-${{ hashFiles('Example/Podfile.lock') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: macos-latest
     steps:
       # Checkout with custom token for pushin to protected branch
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
 

--- a/Example/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example/Example.xcodeproj/project.pbxproj
@@ -213,7 +213,6 @@
 				230878282A8D3E3A00AEB6A7 /* Sources */,
 				230878292A8D3E3A00AEB6A7 /* Frameworks */,
 				2308782A2A8D3E3A00AEB6A7 /* Resources */,
-				D6FF114F4C4DB27F3E913981 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -252,7 +251,6 @@
 				2322FDE82AD4696D00F56303 /* Sources */,
 				2322FDEA2AD4696D00F56303 /* Frameworks */,
 				2322FDEC2AD4696D00F56303 /* Resources */,
-				70EACFF8425A8FB45710E1B7 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -417,23 +415,6 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ExampleFrameworks/Pods-ExampleFrameworks-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		70EACFF8425A8FB45710E1B7 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-ExampleLibsTests/Pods-ExampleLibsTests-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-ExampleLibsTests/Pods-ExampleLibsTests-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ExampleLibsTests/Pods-ExampleLibsTests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		9FE67ADA4DDC9B3DCE39540B /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -493,23 +474,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ExampleFrameworks/Pods-ExampleFrameworks-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		D6FF114F4C4DB27F3E913981 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-ExampleFrameworksTests/Pods-ExampleFrameworksTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-ExampleFrameworksTests/Pods-ExampleFrameworksTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ExampleFrameworksTests/Pods-ExampleFrameworksTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/Example/Example/ExampleTests/ExampleTests.swift
+++ b/Example/Example/ExampleTests/ExampleTests.swift
@@ -1,5 +1,4 @@
 import Alamofire
-import AutoMate
 import KeyboardLayoutGuide
 import Kingfisher
 import Moya

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -12,7 +12,6 @@ target 'ExampleFrameworks' do
 
   target 'ExampleFrameworksTests' do
     inherit! :search_paths
-    pod 'AutoMate'
   end
 end
 
@@ -27,7 +26,6 @@ target 'ExampleLibs' do
 
   target 'ExampleLibsTests' do
     inherit! :search_paths
-    pod 'AutoMate'
   end
 end
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,6 +1,5 @@
 PODS:
   - Alamofire (5.8.0)
-  - AutoMate (1.8.0)
   - "Keyboard+LayoutGuide (1.6.0)"
   - Kingfisher (7.9.1)
   - LocalPod (1.0.0):
@@ -14,7 +13,6 @@ PODS:
   - SnapKit (5.6.0)
 
 DEPENDENCIES:
-  - AutoMate
   - "Keyboard+LayoutGuide"
   - Kingfisher
   - LocalPod (from `LocalPods`)
@@ -26,7 +24,6 @@ DEPENDENCIES:
 SPEC REPOS:
   trunk:
     - Alamofire
-    - AutoMate
     - "Keyboard+LayoutGuide"
     - Kingfisher
     - Moya
@@ -38,13 +35,12 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Alamofire: 0e92e751b3e9e66d7982db43919d01f313b8eb91
-  AutoMate: e73f192ba530a60c01e1803f391f28bc154dd9ec
   "Keyboard+LayoutGuide": db44b1764e2bb5d9824cc9cea9d9006cd4442045
   Kingfisher: 1d14e9f59cbe19389f591c929000332bf70efd32
   LocalPod: 98c9e510a9ffb889839862aafcde67a1bd2e503f
   Moya: 138f0573e53411fb3dc17016add0b748dfbd78ee
   SnapKit: e01d52ebb8ddbc333eefe2132acf85c8227d9c25
 
-PODFILE CHECKSUM: 68b380e021774eb655075ed785b0db9f6d8d3a2e
+PODFILE CHECKSUM: 7744094d93dba5bb608143d42834f7d636b428e3
 
-COCOAPODS: 1.12.1
+COCOAPODS: 1.14.3


### PR DESCRIPTION
### Description
<!--Please describe your pull request.-->
I've fixed some GitHub action issues:
- Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3.
    For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
- Run `swiftformat . --lint --quiet --reporter github-actions-log`
    error: Unknown rule 'preferForLoop'. Did you mean 'preferKeyPath'?
- [Smoke (Libraries): Example/Pods/AutoMate/AutoMate/XCTest extensions/XCTestCase.swift#L51](https://github.com/swiftyfinch/Rugby/pull/327/files#annotation_18091860500)
    'recordFailure(withDescription:inFile:atLine:expected:)' is deprecated: Replaced by 'record(_:)'

### References
<!--Provide links to an existing issue or external references/discussions, if appropriate.-->
- None

### Checklist (I have ...)
- [x] 🧐 Followed the code style of the rest of the project
- [ ] 📖 Updated the documentation, if necessary
- [ ] 👨🏻‍🔧 Added at least one test which validates that my change is working, if appropriate
- [x] 👮🏻‍♂️ Run `make lint` and fixed all warnings
- [x] ✅ Run `make test` and fixed all tests

❤️ Thanks for contributing to the 🏈 Rugby!
