### PR TITLE
🐛 Fix adding transitive dependency in multi-project configuration

### DIFF
--- a/Sources/RugbyFoundation/XcodeProject/Extensions/XcodeProj/PBXProj/PBXProj+Dependencies.swift
+++ b/Sources/RugbyFoundation/XcodeProject/Extensions/XcodeProj/PBXProj/PBXProj+Dependencies.swift
@@ -34,6 +34,7 @@ extension PBXProj {
             if let existingReference = projectReferences().first(where: { $0.name == reference.name }) {
                 containerPortal = .fileReference(existingReference)
             } else {
+                reference.fixRelativeProjectPath()
                 add(object: reference)
 
                 // Add project dependency to root Dependencies group
@@ -77,6 +78,14 @@ extension PBXProj {
         }
         target.pbxTarget.dependencies.removeAll(where: pbxDependencies.contains)
         target.deleteDependencies(dependencies)
+    }
+}
+
+private extension PBXFileReference {
+    func fixRelativeProjectPath() {
+        // Sometimes a project path is relative to the project:
+        // For example, '../../Pods/SnapKit.xcodeproj' should be 'SnapKit.xcodeproj'.
+        path = path.map(URL.init(fileURLWithPath:))?.lastPathComponent
     }
 }
 


### PR DESCRIPTION
### Description
<!--Please describe your pull request.-->
Sometimes a project path is relative to the project.
For example, `'../../Pods/SnapKit.xcodeproj'` should be `'SnapKit.xcodeproj'`.
It breaks adding a transitive dependency from an another subproject explicitly.

### References
<!--Provide links to an existing issue or external references/discussions, if appropriate.-->
- None

### Checklist (I have ...)
- [x] 🧐 Followed the code style of the rest of the project
- [ ] 📖 Updated the documentation, if necessary
- [ ] 👨🏻‍🔧 Added at least one test which validates that my change is working, if appropriate
- [x] 👮🏻‍♂️ Run `make lint` and fixed all warnings
- [x] ✅ Run `make test` and fixed all tests

❤️ Thanks for contributing to the 🏈 Rugby!
