### PR TITLE
🚀 Add option `--up-to-date-branch` to `test pass` command

### DIFF
--- a/Docs/commands-help/test/pass.md
+++ b/Docs/commands-help/test/pass.md
@@ -11,16 +11,17 @@
  > (Experimental) Mark test targets as passed.
 
  Options:
-╭───────────────────────────────────────────────────────────────────────────────╮
-│ -s, --sdk                  * Build SDK: sim or ios.                           │
-│ -a, --arch                 * Build architecture: auto, x86_64 or arm64.       │
-│ -c, --config               * Build configuration. (Debug)                     │
-│ -t, --targets []           * Target names to select. Empty means all targets. │
-│ -g, --targets-as-regex []  * Regular expression patterns to select targets.   │
-│ -e, --except []            * Target names to exclude.                         │
-│ -x, --except-as-regex []   * Regular expression patterns to exclude targets.  │
-│ -o, --output               * Output mode: fold, multiline, silent, raw.       │
-╰───────────────────────────────────────────────────────────────────────────────╯
+╭──────────────────────────────────────────────────────────────────────────────────────────╮
+│ -u, --up-to-date-branch    * Skip if the current branch is not up-to-date to target one. │
+│ -s, --sdk                  * Build SDK: sim or ios.                                      │
+│ -a, --arch                 * Build architecture: auto, x86_64 or arm64.                  │
+│ -c, --config               * Build configuration. (Debug)                                │
+│ -t, --targets []           * Target names to select. Empty means all targets.            │
+│ -g, --targets-as-regex []  * Regular expression patterns to select targets.              │
+│ -e, --except []            * Target names to exclude.                                    │
+│ -x, --except-as-regex []   * Regular expression patterns to exclude targets.             │
+│ -o, --output               * Output mode: fold, multiline, silent, raw.                  │
+╰──────────────────────────────────────────────────────────────────────────────────────────╯
  Flags:
 ╭──────────────────────────────────────────────────╮
 │ --strip           * Build without debug symbols. │

--- a/Sources/Rugby/Commands/Basic/Test.swift
+++ b/Sources/Rugby/Commands/Basic/Test.swift
@@ -59,6 +59,9 @@ private extension Test {
             discussion: Links.commandsHelp("test/pass.md")
         )
 
+        @Option(name: .shortAndLong, help: "Skip if the current branch is not up-to-date to \("target one".yellow).")
+        var upToDateBranch: String?
+
         @OptionGroup
         var buildOptions: BuildOptions
 
@@ -82,7 +85,8 @@ private extension Test {
                         patterns: buildOptions.targetsOptions.exceptAsRegex,
                         exactMatches: buildOptions.targetsOptions.exceptTargets
                     ),
-                    buildOptions: buildOptions.xcodeBuildOptions()
+                    buildOptions: buildOptions.xcodeBuildOptions(),
+                    upToDateBranch: upToDateBranch
                 )
         }
     }

--- a/Sources/Rugby/Core/Routing.swift
+++ b/Sources/Rugby/Core/Routing.swift
@@ -8,4 +8,5 @@ extension IRouter {
     }
 
     var plansRelativePath: String { ".rugby/plans.yml" }
+    var logName: String { "rugby.log" }
 }

--- a/Sources/Rugby/Core/RunnableCommand/RunnableCommand.swift
+++ b/Sources/Rugby/Core/RunnableCommand/RunnableCommand.swift
@@ -89,7 +89,7 @@ extension RunnableCommand {
 
     private func prepareLogger(outputType: OutputType, logLevel: LogLevel) async throws {
         let logFolder = try dependencies.logsRotator.currentLogFolder()
-        let logFile = try logFolder.createFile(named: "rugby.log")
+        let logFile = try logFolder.createFile(named: dependencies.router.logName)
         let filePrinter = FilePrinter(file: logFile)
 
         var outputType = outputType

--- a/Sources/RugbyFoundation/Core/Common/Git.swift
+++ b/Sources/RugbyFoundation/Core/Common/Git.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+// MARK: - Interface
+
+protocol IGit: AnyObject {
+    func currentBranch() throws -> String?
+    func hasUncommittedChanges() throws -> Bool
+    func isBehind(branch: String) throws -> Bool
+}
+
+enum GitError: LocalizedError {
+    case nilOutput
+
+    var errorDescription: String? {
+        switch self {
+        case .nilOutput:
+            return "The git command returned nil."
+        }
+    }
+}
+
+// MARK: - Implementation
+
+final class Git {
+    private let shellExecutor: IShellExecutor
+
+    init(shellExecutor: IShellExecutor) {
+        self.shellExecutor = shellExecutor
+    }
+
+    private func run(_ command: String) throws -> String {
+        guard let output = try shellExecutor.throwingShell(command) else {
+            throw GitError.nilOutput
+        }
+        return output
+    }
+}
+
+// MARK: - IGit
+
+extension Git: IGit {
+    func currentBranch() throws -> String? {
+        try run("git branch --show-current")
+    }
+
+    func hasUncommittedChanges() throws -> Bool {
+        try run("git status --porcelain").isNotEmpty
+    }
+
+    func isBehind(branch: String) throws -> Bool {
+        try run("git rev-list \(branch)...").isNotEmpty
+    }
+}

--- a/Sources/RugbyFoundation/Core/Env/EnvironmentCollector.swift
+++ b/Sources/RugbyFoundation/Core/Env/EnvironmentCollector.swift
@@ -42,19 +42,22 @@ final class EnvironmentCollector: Loggable {
     private let swiftVersionProvider: ISwiftVersionProvider
     private let architectureProvider: IArchitectureProvider
     private let xcodeCLTVersionProvider: IXcodeCLTVersionProvider
+    private let git: IGit
 
     init(logger: ILogger,
          workingDirectory: IFolder,
          shellExecutor: IShellExecutor,
          swiftVersionProvider: ISwiftVersionProvider,
          architectureProvider: IArchitectureProvider,
-         xcodeCLTVersionProvider: IXcodeCLTVersionProvider) {
+         xcodeCLTVersionProvider: IXcodeCLTVersionProvider,
+         git: IGit) {
         self.logger = logger
         self.workingDirectory = workingDirectory
         self.shellExecutor = shellExecutor
         self.swiftVersionProvider = swiftVersionProvider
         self.architectureProvider = architectureProvider
         self.xcodeCLTVersionProvider = xcodeCLTVersionProvider
+        self.git = git
     }
 
     // MARK: - Private
@@ -78,8 +81,7 @@ final class EnvironmentCollector: Loggable {
     }
 
     private func getGitBranch() -> String {
-        let branch = try? shellExecutor.throwingShell("git branch --show-current")?
-            .trimmingCharacters(in: .newlines)
+        let branch = try? git.currentBranch()
         return "Git branch: \(branch ?? .unknown)"
     }
 

--- a/Sources/RugbyFoundation/Core/Test/TestImpactManager.swift
+++ b/Sources/RugbyFoundation/Core/Test/TestImpactManager.swift
@@ -123,10 +123,10 @@ extension TestImpactManager: ITestImpactManager {
                       upToDateBranch: String?) async throws {
         if let branch = upToDateBranch {
             guard try !git.hasUncommittedChanges() else {
-                return await log("Skip: the current branch has uncommitted changes.")
+                return await log("Skip: The current branch has uncommitted changes.")
             }
             guard try !git.isBehind(branch: branch) else {
-                return await log("Skip: the current branch is behind \(branch).")
+                return await log("Skip: The current branch is behind \(branch).")
             }
         }
 

--- a/Sources/RugbyFoundation/Vault/Commands/Vault+Test.swift
+++ b/Sources/RugbyFoundation/Vault/Commands/Vault+Test.swift
@@ -18,7 +18,8 @@ public extension Vault {
                 logger: logger,
                 binariesStorage: binariesStorage,
                 sharedPath: router.testsImpactFolderPath
-            )
+            ),
+            git: git
         )
     }
 }

--- a/Sources/RugbyFoundation/Vault/Vault.swift
+++ b/Sources/RugbyFoundation/Vault/Vault.swift
@@ -80,7 +80,8 @@ public final class Vault {
         shellExecutor: shellExecutor,
         swiftVersionProvider: swiftVersionProvider,
         architectureProvider: architectureProvider,
-        xcodeCLTVersionProvider: XcodeCLTVersionProvider(shellExecutor: shellExecutor)
+        xcodeCLTVersionProvider: XcodeCLTVersionProvider(shellExecutor: shellExecutor),
+        git: git
     )
 
     // MARK: - Logs
@@ -93,6 +94,7 @@ public final class Vault {
 
     // MARK: - Common
 
+    private(set) lazy var git = Git(shellExecutor: shellExecutor)
     private(set) lazy var binariesStorage = BinariesStorage(
         logger: logger,
         sharedPath: router.binFolderPath,

--- a/Tests/FoundationTests/Core/Common/GitTests.swift
+++ b/Tests/FoundationTests/Core/Common/GitTests.swift
@@ -1,0 +1,128 @@
+@testable import RugbyFoundation
+import XCTest
+
+final class GitTests: XCTestCase {
+    private enum TestError: Error { case test }
+
+    private var sut: IGit!
+    private var shellExecutor: IShellExecutorMock!
+
+    override func setUp() {
+        super.setUp()
+        shellExecutor = IShellExecutorMock()
+        sut = Git(shellExecutor: shellExecutor)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        shellExecutor = nil
+        sut = nil
+    }
+}
+
+extension GitTests {
+    func test_currentBranch_error() async throws {
+        shellExecutor.throwingShellArgsThrowableError = TestError.test
+
+        // Act
+        var resultError: Error?
+        do {
+            _ = try sut.currentBranch()
+        } catch {
+            resultError = error
+        }
+
+        // Assert
+        XCTAssertEqual(resultError as? TestError, .test)
+        XCTAssertFalse(shellExecutor.throwingShellArgsCalled)
+    }
+
+    func test_currentBranch_gitError() throws {
+        shellExecutor.throwingShellArgsReturnValue = nil
+
+        // Act
+        var resultError: Error?
+        do {
+            _ = try sut.currentBranch()
+        } catch {
+            resultError = error
+        }
+
+        // Assert
+        XCTAssertEqual(resultError as? GitError, .nilOutput)
+        XCTAssertEqual(shellExecutor.throwingShellArgsCallsCount, 1)
+        XCTAssertEqual(shellExecutor.throwingShellArgsReceivedArguments?.command, "git branch --show-current")
+        let args = try XCTUnwrap(shellExecutor.throwingShellArgsReceivedArguments?.args as? [Any])
+        XCTAssertTrue(args.isEmpty)
+    }
+
+    func test_currentBranch() throws {
+        shellExecutor.throwingShellArgsReturnValue = "fix-something"
+
+        // Act
+        let branch = try sut.currentBranch()
+
+        // Assert
+        XCTAssertEqual(branch, "fix-something")
+        XCTAssertEqual(shellExecutor.throwingShellArgsCallsCount, 1)
+        XCTAssertEqual(shellExecutor.throwingShellArgsReceivedArguments?.command, "git branch --show-current")
+        let args = try XCTUnwrap(shellExecutor.throwingShellArgsReceivedArguments?.args as? [Any])
+        XCTAssertTrue(args.isEmpty)
+    }
+
+    func test_hasUncommittedChanges_true() throws {
+        shellExecutor.throwingShellArgsReturnValue = " M Sources/RugbyFoundation/Core/Env/SwiftVersionProvider.swift"
+
+        // Act
+        let hasUncommittedChanges = try sut.hasUncommittedChanges()
+
+        // Assert
+        XCTAssertTrue(hasUncommittedChanges)
+        XCTAssertEqual(shellExecutor.throwingShellArgsCallsCount, 1)
+        XCTAssertEqual(shellExecutor.throwingShellArgsReceivedArguments?.command, "git status --porcelain")
+        let args = try XCTUnwrap(shellExecutor.throwingShellArgsReceivedArguments?.args as? [Any])
+        XCTAssertTrue(args.isEmpty)
+    }
+
+    func test_hasUncommittedChanges_false() throws {
+        shellExecutor.throwingShellArgsReturnValue = ""
+
+        // Act
+        let hasUncommittedChanges = try sut.hasUncommittedChanges()
+
+        // Assert
+        XCTAssertFalse(hasUncommittedChanges)
+        XCTAssertEqual(shellExecutor.throwingShellArgsCallsCount, 1)
+        XCTAssertEqual(shellExecutor.throwingShellArgsReceivedArguments?.command, "git status --porcelain")
+        let args = try XCTUnwrap(shellExecutor.throwingShellArgsReceivedArguments?.args as? [Any])
+        XCTAssertTrue(args.isEmpty)
+    }
+
+    func test_isBehind_true() throws {
+        shellExecutor.throwingShellArgsReturnValue = "1286ae00c58981e7babd1b6d737df5d9f466d4e9"
+
+        // Act
+        let isBehind = try sut.isBehind(branch: "main")
+
+        // Assert
+        XCTAssertTrue(isBehind)
+        XCTAssertEqual(shellExecutor.throwingShellArgsCallsCount, 1)
+        XCTAssertEqual(shellExecutor.throwingShellArgsReceivedArguments?.command, "git rev-list main...")
+        let args = try XCTUnwrap(shellExecutor.throwingShellArgsReceivedArguments?.args as? [Any])
+        XCTAssertTrue(args.isEmpty)
+    }
+
+    func test_isBehind_false() throws {
+        shellExecutor.throwingShellArgsReturnValue = ""
+
+        // Act
+        let isBehind = try sut.isBehind(branch: "main")
+
+        // Assert
+        XCTAssertFalse(isBehind)
+        XCTAssertEqual(shellExecutor.throwingShellArgsCallsCount, 1)
+        XCTAssertEqual(shellExecutor.throwingShellArgsReceivedArguments?.command, "git rev-list main...")
+        let args = try XCTUnwrap(shellExecutor.throwingShellArgsReceivedArguments?.args as? [Any])
+        XCTAssertTrue(args.isEmpty)
+    }
+}

--- a/Tests/FoundationTests/Core/Env/EnvironmentCollectorTests.swift
+++ b/Tests/FoundationTests/Core/Env/EnvironmentCollectorTests.swift
@@ -10,6 +10,7 @@ final class EnvironmentCollectorTests: XCTestCase {
     private var swiftVersionProvider: ISwiftVersionProviderMock!
     private var architectureProvider: IArchitectureProviderMock!
     private var xcodeCLTVersionProvider: IXcodeCLTVersionProviderMock!
+    private var git: IGitMock!
 
     override func setUp() {
         super.setUp()
@@ -19,13 +20,15 @@ final class EnvironmentCollectorTests: XCTestCase {
         swiftVersionProvider = ISwiftVersionProviderMock()
         architectureProvider = IArchitectureProviderMock()
         xcodeCLTVersionProvider = IXcodeCLTVersionProviderMock()
+        git = IGitMock()
         sut = EnvironmentCollector(
             logger: logger,
             workingDirectory: workingDirectory,
             shellExecutor: shellExecutor,
             swiftVersionProvider: swiftVersionProvider,
             architectureProvider: architectureProvider,
-            xcodeCLTVersionProvider: xcodeCLTVersionProvider
+            xcodeCLTVersionProvider: xcodeCLTVersionProvider,
+            git: git
         )
     }
 
@@ -37,6 +40,7 @@ final class EnvironmentCollectorTests: XCTestCase {
         swiftVersionProvider = nil
         architectureProvider = nil
         xcodeCLTVersionProvider = nil
+        git = nil
         sut = nil
     }
 }
@@ -62,6 +66,7 @@ extension EnvironmentCollectorTests {
             "RUGBY_KEEP_HASH_YAMLS": "YES",
             "RUGBY_PRINT_MISSING_BINARIES": "NO"
         ]
+        git.currentBranchReturnValue = "main"
 
         // Act
         let env = try await sut.env(

--- a/Tests/FoundationTests/Core/Test/TestImpactManagerTests.swift
+++ b/Tests/FoundationTests/Core/Test/TestImpactManagerTests.swift
@@ -77,6 +77,7 @@ extension TestImpactManagerTests {
         }
 
         // Assert
+        XCTAssertFalse(logger.logLevelOutputCalled)
         XCTAssertEqual(environmentCollector.logXcodeVersionCallsCount, 1)
         XCTAssertEqual(rugbyXcodeProject.isAlreadyUsingRugbyCallsCount, 1)
         XCTAssertEqual(resultError as? RugbyError, .alreadyUseRugby)
@@ -121,6 +122,7 @@ extension TestImpactManagerTests {
 
         // Assert
         XCTAssertEqual(loggerBlockInvocations.count, 3)
+        XCTAssertFalse(logger.logLevelOutputCalled)
 
         XCTAssertEqual(buildTargetsManager.findTargetsExceptTargetsIncludingTestsCallsCount, 1)
         let findTargets = try XCTUnwrap(buildTargetsManager.findTargetsExceptTargetsIncludingTestsReceivedArguments)
@@ -165,6 +167,13 @@ extension TestImpactManagerTests {
         // Assert
         XCTAssertTrue(git.hasUncommittedChangesCalled)
         XCTAssertFalse(git.isBehindBranchCalled)
+
+        XCTAssertEqual(logger.logLevelOutputCallsCount, 1)
+        XCTAssertEqual(logger.logLevelOutputReceivedArguments?.level, .compact)
+        XCTAssertEqual(logger.logLevelOutputReceivedArguments?.output, .all)
+        XCTAssertEqual(logger.logLevelOutputReceivedArguments?.text,
+                       "Skip: The current branch has uncommitted changes.")
+
         XCTAssertTrue(loggerBlockInvocations.isEmpty)
         XCTAssertFalse(buildTargetsManager.findTargetsExceptTargetsIncludingTestsCalled)
         XCTAssertFalse(targetsHasher.hashXcargsCalled)
@@ -187,6 +196,13 @@ extension TestImpactManagerTests {
         XCTAssertTrue(git.hasUncommittedChangesCalled)
         XCTAssertTrue(git.isBehindBranchCalled)
         XCTAssertEqual(git.isBehindBranchReceivedBranch, "main")
+
+        XCTAssertEqual(logger.logLevelOutputCallsCount, 1)
+        XCTAssertEqual(logger.logLevelOutputReceivedArguments?.level, .compact)
+        XCTAssertEqual(logger.logLevelOutputReceivedArguments?.output, .all)
+        XCTAssertEqual(logger.logLevelOutputReceivedArguments?.text,
+                       "Skip: The current branch is behind main.")
+
         XCTAssertTrue(loggerBlockInvocations.isEmpty)
         XCTAssertFalse(buildTargetsManager.findTargetsExceptTargetsIncludingTestsCalled)
         XCTAssertFalse(targetsHasher.hashXcargsCalled)
@@ -231,6 +247,7 @@ extension TestImpactManagerTests {
         XCTAssertEqual(git.isBehindBranchReceivedBranch, "dev")
 
         XCTAssertEqual(loggerBlockInvocations.count, 3)
+        XCTAssertFalse(logger.logLevelOutputCalled)
 
         XCTAssertEqual(buildTargetsManager.findTargetsExceptTargetsIncludingTestsCallsCount, 1)
         let findTargets = try XCTUnwrap(buildTargetsManager.findTargetsExceptTargetsIncludingTestsReceivedArguments)

--- a/Tests/FoundationTests/Mocks/IGitMock.generated.swift
+++ b/Tests/FoundationTests/Mocks/IGitMock.generated.swift
@@ -1,0 +1,76 @@
+// Generated using Sourcery 2.1.1 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+// swiftlint:disable all
+
+import Foundation
+@testable import RugbyFoundation
+
+final class IGitMock: IGit {
+
+    // MARK: - currentBranch
+
+    var currentBranchThrowableError: Error?
+    var currentBranchCallsCount = 0
+    var currentBranchCalled: Bool { currentBranchCallsCount > 0 }
+    var currentBranchReturnValue: String?
+    var currentBranchClosure: (() throws -> String?)?
+
+    func currentBranch() throws -> String? {
+        if let error = currentBranchThrowableError {
+            throw error
+        }
+        currentBranchCallsCount += 1
+        if let currentBranchClosure = currentBranchClosure {
+            return try currentBranchClosure()
+        } else {
+            return currentBranchReturnValue
+        }
+    }
+
+    // MARK: - hasUncommittedChanges
+
+    var hasUncommittedChangesThrowableError: Error?
+    var hasUncommittedChangesCallsCount = 0
+    var hasUncommittedChangesCalled: Bool { hasUncommittedChangesCallsCount > 0 }
+    var hasUncommittedChangesReturnValue: Bool!
+    var hasUncommittedChangesClosure: (() throws -> Bool)?
+
+    func hasUncommittedChanges() throws -> Bool {
+        if let error = hasUncommittedChangesThrowableError {
+            throw error
+        }
+        hasUncommittedChangesCallsCount += 1
+        if let hasUncommittedChangesClosure = hasUncommittedChangesClosure {
+            return try hasUncommittedChangesClosure()
+        } else {
+            return hasUncommittedChangesReturnValue
+        }
+    }
+
+    // MARK: - isBehind
+
+    var isBehindBranchThrowableError: Error?
+    var isBehindBranchCallsCount = 0
+    var isBehindBranchCalled: Bool { isBehindBranchCallsCount > 0 }
+    var isBehindBranchReceivedBranch: String?
+    var isBehindBranchReceivedInvocations: [String] = []
+    var isBehindBranchReturnValue: Bool!
+    var isBehindBranchClosure: ((String) throws -> Bool)?
+
+    func isBehind(branch: String) throws -> Bool {
+        if let error = isBehindBranchThrowableError {
+            throw error
+        }
+        isBehindBranchCallsCount += 1
+        isBehindBranchReceivedBranch = branch
+        isBehindBranchReceivedInvocations.append(branch)
+        if let isBehindBranchClosure = isBehindBranchClosure {
+            return try isBehindBranchClosure(branch)
+        } else {
+            return isBehindBranchReturnValue
+        }
+    }
+}
+
+// swiftlint:enable all

--- a/Tests/FoundationTests/Mocks/Mocks.swift
+++ b/Tests/FoundationTests/Mocks/Mocks.swift
@@ -142,4 +142,7 @@ extension IInternalXcodeProject {}
 //// sourcery: AutoMockable, imports = ["RugbyFoundation"]
 extension IInternalBuildManager {}
 
+//// sourcery: AutoMockable, imports = ["RugbyFoundation"]
+extension IGit {}
+
 // TODO: Needs to improve Sourcery template to generate mocks automatically w/o manual editing


### PR DESCRIPTION
### Description
<!--Please describe your pull request.-->
I've added ability to mark test passed only if there are no git changes and the current branch is not behind to target one.
```shell
> rugby _test pass --up-to-date-branch main
> rugby _test pass -u main
```

The main idea is to use it in `rugby/plans.yml`:
```yml
basic:
- command: shell
  argument: pod install
- command: _test pass
  up-to-date-branch: main
- command: cache
```
It will mark all test targets as passed after creating a new fresh git branch.
And will skip it if you are already in the middle of your working process and use the `rugby basic` plan again.

### References
<!--Provide links to an existing issue or external references/discussions, if appropriate.-->
- None

### Checklist (I have ...)
- [x] 🧐 Followed the code style of the rest of the project
- [x] 📖 Updated the documentation, if necessary
- [x] 👨🏻‍🔧 Added at least one test which validates that my change is working, if appropriate
- [x] 👮🏻‍♂️ Run `make lint` and fixed all warnings
- [x] ✅ Run `make test` and fixed all tests

❤️ Thanks for contributing to the 🏈 Rugby!
