### PR TITLE
🐛 Rewrite backup folders instead of copying files

### DIFF
--- a/Sources/RugbyFoundation/Core/Rollback/BackupManager.swift
+++ b/Sources/RugbyFoundation/Core/Rollback/BackupManager.swift
@@ -30,12 +30,15 @@ public enum BackupKind: String {
 
 enum BackupManagerError: LocalizedError {
     case missingBackup
+    case unexpectedBackupStructure
 
     var errorDescription: String? {
         let output: String
         switch self {
         case .missingBackup:
             output = "Can't find backup."
+        case .unexpectedBackupStructure:
+            output = "Unexpected backup structure."
         }
         return output
     }
@@ -52,6 +55,7 @@ final class BackupManager {
 
     private let yes = "YES"
     private let targetSupportFiles = "Target Support Files"
+    private let partialBackupPodsFolder = "Pods"
 
     init(backupFolderPath: String,
          workingDirectory: IFolder,
@@ -107,7 +111,7 @@ extension BackupManager {
 // MARK: - Private Restore
 
 extension BackupManager {
-    private func restoreSteps(from subfolderName: String) throws -> [(source: IFile, target: String)] {
+    private func restoreSteps(from subfolderName: String) throws -> [(source: IFolder, target: String)] {
         let backupFolderPath = backupFolderPath(subfolderName: subfolderName)
         guard let backupFolder = try? Folder.at(backupFolderPath),
               try !backupFolder.isEmpty() else { throw Error.missingBackup }
@@ -115,11 +119,19 @@ extension BackupManager {
         return try restoreSteps(from: backupFolder)
     }
 
-    private func restoreSteps(from backupFolder: IFolder) throws -> [(source: IFile, target: String)] {
+    private func restoreSteps(from backupFolder: IFolder) throws -> [(source: IFolder, target: String)] {
         let subfolders = try backupFolder.folders()
-        return try subfolders.flatMap { folder -> [(source: IFile, target: String)] in
-            let files = try folder.files(deep: true)
-            return files.compactMap { file in
+        return try subfolders.flatMap { folder -> [(source: IFolder, target: String)] in
+            let adjustedFolder: IFolder
+            if folder.name == partialBackupPodsFolder {
+                guard let childrenFolder = try folder.folders().first else { throw Error.unexpectedBackupStructure }
+                adjustedFolder = childrenFolder
+            } else {
+                adjustedFolder = folder
+            }
+
+            let folders = try adjustedFolder.folders()
+            return folders.compactMap { file in
                 guard let destinationFolderSubpath = file.parent?.relativePath(to: folder) else { return nil }
                 return (file, workingDirectory.subpath(destinationFolderSubpath))
             }
@@ -130,13 +142,13 @@ extension BackupManager {
 // MARK: - Common Steps
 
 extension BackupManager {
-    private func applySteps(_ steps: [(source: IFile, target: String)]) async throws {
+    private func applySteps(_ steps: [(source: IItem, target: String)]) async throws {
         try await steps.concurrentForEach { file, folderPath in
             try file.copy(to: folderPath, replace: true)
         }
     }
 
-    private func applySteps(_ steps: [(source: IFile, target: String)]) throws {
+    private func applySteps(_ steps: [(source: IItem, target: String)]) throws {
         try steps.forEach { file, folderPath in
             try file.copy(to: folderPath, replace: true)
         }

--- a/Tests/FoundationTests/Core/Rollback/BackupManagerTests.swift
+++ b/Tests/FoundationTests/Core/Rollback/BackupManagerTests.swift
@@ -196,6 +196,8 @@ extension BackupManagerTests {
         let pods = try originalFolder.createFolder(named: "Pods").createFolder(named: "Pods")
         let projectFolder = try pods.createFolder(named: "Pods.xcodeproj")
         try projectFolder.createFile(named: "project.pbxproj", contents: "test_pbxproj_content")
+        let xcschemes = try projectFolder.createFolder(named: "xcuserdata/swiftyfinch.xcuserdatad/xcschemes")
+        try xcschemes.createFile(named: "Pods-ExampleFrameworks.xcscheme")
         let workspace = try projectFolder.createFolder(named: "project.xcworkspace")
         try workspace.createFile(named: "contents.xcworkspacedata", contents: "test_workspace_content")
         let targetSupportFiles = try pods.createFolder(named: "Target Support Files")
@@ -209,6 +211,11 @@ extension BackupManagerTests {
                                    contents: "test_podsExample.resources_content")
         try podsExample.createFile(named: "Pods-ExampleFrameworks-frameworks.sh",
                                    contents: "test_podsExample.frameworks_content")
+
+        let currentXCSchemes = try workingDirectory.createFolder(
+            named: "Pods/Pods.xcodeproj/xcuserdata/swiftyfinch.xcuserdatad/xcschemes"
+        )
+        try currentXCSchemes.createFile(named: "RugbyPods.xcscheme")
 
         // Act
         try await sut.asyncRestore(.original)
@@ -229,6 +236,12 @@ extension BackupManagerTests {
         )))
         XCTAssertTrue(File.isExist(at: workingDirectory.subpath(
             "Pods/Target Support Files/Pods-ExampleFrameworks/Pods-ExampleFrameworks-resources.sh"
+        )))
+        XCTAssertTrue(File.isExist(at: workingDirectory.subpath(
+            "Pods/Pods.xcodeproj/xcuserdata/swiftyfinch.xcuserdatad/xcschemes/Pods-ExampleFrameworks.xcscheme"
+        )))
+        XCTAssertFalse(File.isExist(at: workingDirectory.subpath(
+            "Pods/Pods.xcodeproj/xcuserdata/swiftyfinch.xcuserdatad/xcschemes/RugbyPods.xcscheme"
         )))
     }
 


### PR DESCRIPTION
### Description
<!--Please describe your pull request.-->
In some cases it is necessary to rewrite a whole folder during restoring a backup.
For example, when an original Pods folder contains a temporary Rugby scheme.

### References
<!--Provide links to an existing issue or external references/discussions, if appropriate.-->
- None

### Checklist (I have ...)
- [x] 🧐 Followed the code style of the rest of the project
- [ ] 📖 Updated the documentation, if necessary
- [x] 👨🏻‍🔧 Added at least one test which validates that my change is working, if appropriate
- [x] 👮🏻‍♂️ Run `make lint` and fixed all warnings
- [x] ✅ Run `make test` and fixed all tests

❤️ Thanks for contributing to the 🏈 Rugby!
