### PR TITLE
Add flag `--skip-signing`

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -109,7 +109,11 @@ jobs:
 
     - name: Rugby
       working-directory: ./Example
-      run: rugby --prebuild --targets Pods-ExampleFrameworks --output multiline
+      run: |
+        rugby --prebuild \
+              --targets Pods-ExampleFrameworks \
+              --strip \
+              --skip-signing \
 
     - run: brew install xcbeautify
     - name: XcodeBuild Test
@@ -147,7 +151,11 @@ jobs:
 
     - name: Rugby
       working-directory: ./Example
-      run: rugby --prebuild --targets Pods-ExampleLibs --output multiline
+      run: |
+        rugby --prebuild \
+              --targets Pods-ExampleLibs \
+              --strip \
+              --skip-signing \
 
     - run: brew install xcbeautify
     - name: XcodeBuild Test
@@ -188,6 +196,8 @@ jobs:
       working-directory: ./Example
       run: |
         rugby _test --targets-as-regex framework \
+                    --strip \
+                    --skip-signing \
                     --simulator-name 'iPhone 14' \
                     --testplan-template-path ExampleFrameworks
 
@@ -216,5 +226,7 @@ jobs:
       working-directory: ./Example
       run: |
         rugby _test --targets-as-regex framework \
+                    --strip \
+                    --skip-signing \
                     --simulator-name 'iPhone 14' \
                     --testplan-template-path ExampleFrameworks

--- a/Docs/commands-help/build/full.md
+++ b/Docs/commands-help/build/full.md
@@ -25,6 +25,7 @@
  Flags:
 ╭──────────────────────────────────────────────────╮
 │ --strip           * Build without debug symbols. │
+│ --skip-signing    * Disable code signing.        │
 │ --ignore-cache    * Ignore shared cache.         │
 │ -v, --verbose []  * Increase verbosity level.    │
 │ -q, --quiet []    * Decrease verbosity level.    │

--- a/Docs/commands-help/shortcuts/cache.md
+++ b/Docs/commands-help/shortcuts/cache.md
@@ -28,6 +28,7 @@
 │ -r, --rollback    * Restore projects state before the last Rugby usage. │
 │ --prebuild        * Prebuild targets ignoring sources.                  │
 │ --strip           * Build without debug symbols.                        │
+│ --skip-signing    * Disable code signing.                               │
 │ --ignore-cache    * Ignore shared cache.                                │
 │ --delete-sources  * Delete target groups from project.                  │
 │ -v, --verbose []  * Increase verbosity level.                           │

--- a/Docs/commands-help/test/impact.md
+++ b/Docs/commands-help/test/impact.md
@@ -24,6 +24,7 @@
  Flags:
 ╭──────────────────────────────────────────────────╮
 │ --strip           * Build without debug symbols. │
+│ --skip-signing    * Disable code signing.        │
 │ -v, --verbose []  * Increase verbosity level.    │
 │ -q, --quiet []    * Decrease verbosity level.    │
 │ -h, --help        * Show help information.       │

--- a/Docs/commands-help/test/pass.md
+++ b/Docs/commands-help/test/pass.md
@@ -25,6 +25,7 @@
  Flags:
 ╭──────────────────────────────────────────────────╮
 │ --strip           * Build without debug symbols. │
+│ --skip-signing    * Disable code signing.        │
 │ -v, --verbose []  * Increase verbosity level.    │
 │ -q, --quiet []    * Decrease verbosity level.    │
 │ -h, --help        * Show help information.       │

--- a/Docs/commands-help/test/run.md
+++ b/Docs/commands-help/test/run.md
@@ -29,6 +29,7 @@
 │ --impact          * Select tests by impact.                               │
 │ --pass            * Mark test targets as passed if all tests are succeed. │
 │ --strip           * Build without debug symbols.                          │
+│ --skip-signing    * Disable code signing.                                 │
 │ -v, --verbose []  * Increase verbosity level.                             │
 │ -q, --quiet []    * Decrease verbosity level.                             │
 │ -h, --help        * Show help information.                                │

--- a/Docs/commands-help/use.md
+++ b/Docs/commands-help/use.md
@@ -22,6 +22,7 @@
 ╭────────────────────────────────────────────────────────╮
 │ --delete-sources  * Delete target groups from project. │
 │ --strip           * Build without debug symbols.       │
+│ --skip-signing    * Disable code signing.              │
 │ -v, --verbose []  * Increase verbosity level.          │
 │ -q, --quiet []    * Decrease verbosity level.          │
 │ -h, --help        * Show help information.             │

--- a/Docs/commands-help/warmup.md
+++ b/Docs/commands-help/warmup.md
@@ -31,6 +31,7 @@
 ╭─────────────────────────────────────────────────────────────────────────────────────────────╮
 │ --analyse         * Run only in analyse mode without downloading. The endpoint is optional. │
 │ --strip           * Build without debug symbols.                                            │
+│ --skip-signing    * Disable code signing.                                                   │
 │ -v, --verbose []  * Increase verbosity level.                                               │
 │ -q, --quiet []    * Decrease verbosity level.                                               │
 │ -h, --help        * Show help information.                                                  │

--- a/Example/Tests/cache_tests.sh
+++ b/Example/Tests/cache_tests.sh
@@ -10,9 +10,9 @@ header "CocoaPods"
 pod install --repo-update
 
 header "Rugby"
-rugby build -t Pods-ExampleFrameworks --output multiline
-rugby build -t Pods-ExampleLibs --output multiline
-rugby use -t Pods-ExampleFrameworks Pods-ExampleLibs --output multiline
+rugby build -t Pods-ExampleFrameworks --strip --skip-signing
+rugby build -t Pods-ExampleLibs --strip --skip-signing
+rugby use -t Pods-ExampleFrameworks Pods-ExampleLibs --strip --skip-signing
 
 header "Test"
 set -o pipefail && env NSUnbufferedIO=YES arch -arm64 xcodebuild test \

--- a/Example/Tests/cache_tests_multiproj.sh
+++ b/Example/Tests/cache_tests_multiproj.sh
@@ -13,4 +13,5 @@ header "Rugby Test"
 rugby _test -g framework \
             -n 'iPhone 15' \
             -p ExampleFrameworks \
-            --output multiline
+            --strip \
+            --skip-signing

--- a/Sources/Rugby/Commands/Basic/Build/AdditionalBuildOptions.swift
+++ b/Sources/Rugby/Commands/Basic/Build/AdditionalBuildOptions.swift
@@ -3,4 +3,7 @@ import ArgumentParser
 struct AdditionalBuildOptions: ParsableCommand {
     @Flag(name: .long, help: "Build without debug symbols.")
     var strip = false
+
+    @Flag(name: .long, help: "Disable code signing.")
+    var skipSigning = false
 }

--- a/Sources/Rugby/Commands/Basic/Build/BuildOptions.swift
+++ b/Sources/Rugby/Commands/Basic/Build/BuildOptions.swift
@@ -21,7 +21,7 @@ struct BuildOptions: AsyncParsableCommand {
     var targetsOptions: TargetsOptions
 
     func xcodeBuildOptions(
-        skipSigning: Bool = false,
+        skipSigning: Bool? = nil,
         resultBundlePath: String? = nil
     ) -> XcodeBuildOptions {
         XcodeBuildOptions(
@@ -30,7 +30,7 @@ struct BuildOptions: AsyncParsableCommand {
             arch: resolveArchitecture().rawValue,
             xcargs: dependencies.xcargsProvider.xcargs(
                 strip: additionalBuildOptions.strip,
-                skipSigning: skipSigning
+                skipSigning: skipSigning ?? additionalBuildOptions.skipSigning
             ),
             resultBundlePath: resultBundlePath
         )

--- a/Sources/Rugby/Commands/Basic/Use.swift
+++ b/Sources/Rugby/Commands/Basic/Use.swift
@@ -42,7 +42,10 @@ extension Use: RunnableCommand {
                     patterns: targetsOptions.exceptAsRegex,
                     exactMatches: targetsOptions.exceptTargets
                 ),
-                xcargs: dependencies.xcargsProvider.xcargs(strip: additionalBuildOptions.strip),
+                xcargs: dependencies.xcargsProvider.xcargs(
+                    strip: additionalBuildOptions.strip,
+                    skipSigning: additionalBuildOptions.skipSigning
+                ),
                 deleteSources: deleteSources
             )
     }


### PR DESCRIPTION
### Description
<!--Please describe your pull request.-->
I've added an ability to disallow code signing.
It can speed up `xcodebuild` process, especially in huge projects.

```sh
> rugby cache --skip-signing
```

I've tested on [devMEremenko/XcodeBenchmark](https://github.com/devMEremenko/XcodeBenchmark) and got ~10% speedup (107/121s).

### References
<!--Provide links to an existing issue or external references/discussions, if appropriate.-->
- None

### Checklist (I have ...)
- [x] 🧐 Followed the code style of the rest of the project
- [x] 📖 Updated the documentation, if necessary
- [x] 👨🏻‍🔧 Added at least one test which validates that my change is working, if appropriate
- [x] 👮🏻‍♂️ Run `make lint` and fixed all warnings
- [x] ✅ Run `make test` and fixed all tests

❤️ Thanks for contributing to the 🏈 Rugby!
