### PR TITLE
🐛 Revert backup changes

### DIFF
--- a/Tests/FoundationTests/Core/Rollback/BackupManagerTests.swift
+++ b/Tests/FoundationTests/Core/Rollback/BackupManagerTests.swift
@@ -196,8 +196,6 @@ extension BackupManagerTests {
         let pods = try originalFolder.createFolder(named: "Pods").createFolder(named: "Pods")
         let projectFolder = try pods.createFolder(named: "Pods.xcodeproj")
         try projectFolder.createFile(named: "project.pbxproj", contents: "test_pbxproj_content")
-        let xcschemes = try projectFolder.createFolder(named: "xcuserdata/swiftyfinch.xcuserdatad/xcschemes")
-        try xcschemes.createFile(named: "Pods-ExampleFrameworks.xcscheme")
         let workspace = try projectFolder.createFolder(named: "project.xcworkspace")
         try workspace.createFile(named: "contents.xcworkspacedata", contents: "test_workspace_content")
         let targetSupportFiles = try pods.createFolder(named: "Target Support Files")
@@ -211,11 +209,6 @@ extension BackupManagerTests {
                                    contents: "test_podsExample.resources_content")
         try podsExample.createFile(named: "Pods-ExampleFrameworks-frameworks.sh",
                                    contents: "test_podsExample.frameworks_content")
-
-        let currentXCSchemes = try workingDirectory.createFolder(
-            named: "Pods/Pods.xcodeproj/xcuserdata/swiftyfinch.xcuserdatad/xcschemes"
-        )
-        try currentXCSchemes.createFile(named: "RugbyPods.xcscheme")
 
         // Act
         try await sut.asyncRestore(.original)
@@ -236,12 +229,6 @@ extension BackupManagerTests {
         )))
         XCTAssertTrue(File.isExist(at: workingDirectory.subpath(
             "Pods/Target Support Files/Pods-ExampleFrameworks/Pods-ExampleFrameworks-resources.sh"
-        )))
-        XCTAssertTrue(File.isExist(at: workingDirectory.subpath(
-            "Pods/Pods.xcodeproj/xcuserdata/swiftyfinch.xcuserdatad/xcschemes/Pods-ExampleFrameworks.xcscheme"
-        )))
-        XCTAssertFalse(File.isExist(at: workingDirectory.subpath(
-            "Pods/Pods.xcodeproj/xcuserdata/swiftyfinch.xcuserdatad/xcschemes/RugbyPods.xcscheme"
         )))
     }
 

--- a/Tests/FoundationTests/Core/Test/TestManagerTests.swift
+++ b/Tests/FoundationTests/Core/Test/TestManagerTests.swift
@@ -249,6 +249,7 @@ extension TestManagerTests {
         let testplanURL = URL(fileURLWithPath: "tests/Rugby.xctestplan")
         testplanEditor.createTestplanTestplanTemplatePathTestTargetsInFolderPathReturnValue = testplanURL
         let testsTarget = IInternalTargetMock()
+        testsTarget.underlyingUuid = "test_RugbyPods_uuid"
         testsTarget.underlyingName = "RugbyPods"
         testsTarget.explicitDependencies = [
             localPodFrameworkUnitTests.uuid: localPodFrameworkUnitTests,
@@ -397,6 +398,12 @@ extension TestManagerTests {
         XCTAssertEqual(loggerBlockInvocations[9].level, .result)
         XCTAssertEqual(loggerBlockInvocations[9].output, .all)
 
+        XCTAssertEqual(xcodeProject.deleteTargetsKeepGroupsCallsCount, 1)
+        let deleteTargetsArgs = try XCTUnwrap(xcodeProject.deleteTargetsKeepGroupsReceivedArguments)
+        XCTAssertEqual(deleteTargetsArgs.targetsForRemove.count, 1)
+        XCTAssertTrue(deleteTargetsArgs.targetsForRemove.contains(testsTarget.uuid))
+        XCTAssertTrue(deleteTargetsArgs.keepGroups)
+
         XCTAssertEqual(loggerBlockInvocations[10].header, "Marking Tests as Passed")
         XCTAssertNil(loggerBlockInvocations[10].footer)
         XCTAssertNil(loggerBlockInvocations[10].metricKey)
@@ -515,6 +522,7 @@ extension TestManagerTests {
         let testplanURL = URL(fileURLWithPath: "tests/Rugby.xctestplan")
         testplanEditor.createTestplanTestplanTemplatePathTestTargetsInFolderPathReturnValue = testplanURL
         let testsTarget = IInternalTargetMock()
+        testsTarget.underlyingUuid = "test_RugbyPods_uuid"
         testsTarget.underlyingName = "RugbyPods"
         testsTarget.explicitDependencies = [
             localPodFrameworkUnitTests.uuid: localPodFrameworkUnitTests,
@@ -663,6 +671,12 @@ extension TestManagerTests {
         XCTAssertEqual(loggerBlockInvocations[9].metricKey, "xcodebuild_test")
         XCTAssertEqual(loggerBlockInvocations[9].level, .result)
         XCTAssertEqual(loggerBlockInvocations[9].output, .all)
+
+        XCTAssertEqual(xcodeProject.deleteTargetsKeepGroupsCallsCount, 1)
+        let deleteTargetsArgs = try XCTUnwrap(xcodeProject.deleteTargetsKeepGroupsReceivedArguments)
+        XCTAssertEqual(deleteTargetsArgs.targetsForRemove.count, 1)
+        XCTAssertTrue(deleteTargetsArgs.targetsForRemove.contains(testsTarget.uuid))
+        XCTAssertTrue(deleteTargetsArgs.keepGroups)
 
         XCTAssertEqual(logger.logLevelOutputReceivedInvocations.count, 4)
         XCTAssertEqual(logger.logLevelOutputReceivedInvocations[0].text, "LocalPod-framework-Unit-Tests")


### PR DESCRIPTION
### Description
<!--Please describe your pull request.-->
I've reverted `backup` command changes, because there was an issue with restoring custom (non-Pods) projects.
And I've added removing the `RugbyPods` scheme outside of restoring process.
This solution looks like more stable one.

### Checklist (I have ...)
- [x] 🧐 Followed the code style of the rest of the project
- [x] 📖 Updated the documentation, if necessary
- [x] 👨🏻‍🔧 Added at least one test which validates that my change is working, if appropriate
- [x] 👮🏻‍♂️ Run `make lint` and fixed all warnings
- [x] ✅ Run `make test` and fixed all tests

❤️ Thanks for contributing to the 🏈 Rugby!
