### PR TITLE
⚙️ Creating a simlink to the latest logs folder

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -112,6 +112,11 @@ jobs:
       run: rugby --prebuild --targets Pods-ExampleFrameworks --output multiline
 
     - run: brew install xcbeautify
+      if: always()
+    - name: Beautify logs
+      if: always()
+      run: cat ~/.rugby/logs/+latest/rawBuild.log 2>&1 | xcbeautify --renderer github-actions
+
     - name: XcodeBuild Test
       working-directory: ./Example
       run: |

--- a/Sources/RugbyFoundation/Core/Build/XcodeBuild/XcodeBuildExecutor.swift
+++ b/Sources/RugbyFoundation/Core/Build/XcodeBuild/XcodeBuildExecutor.swift
@@ -30,7 +30,7 @@ final class XcodeBuildExecutor: IXcodeBuildExecutor, Loggable {
     }
 
     func run(_ command: String, rawLogPath: String, logPath: String, args: Any...) async throws {
-        try Folder.create(at: URL(fileURLWithPath: rawLogPath).deletingLastPathComponent().path)
+        try createRawLogFolder(at: rawLogPath)
         try shellExecutor.throwingShell(command, args: args, "| tee '\(rawLogPath)'")
         try await log("Beautifying Log", block: {
             if let errors = try? await beautifyLog(rawLogPath: rawLogPath, logPath: logPath), errors.isNotEmpty {
@@ -40,6 +40,14 @@ final class XcodeBuildExecutor: IXcodeBuildExecutor, Loggable {
     }
 
     // MARK: - Private
+
+    private func createRawLogFolder(at rawLogPath: String) throws {
+        let folder = try Folder.create(at: URL(fileURLWithPath: rawLogPath).deletingLastPathComponent().path)
+        guard let parent = folder.parent else { return }
+        let latestLogFolderSymlink = "\(parent.path)/+latest"
+        shellExecutor.shell("rm -f \(latestLogFolderSymlink)")
+        try FileManager.default.createSymbolicLink(atPath: latestLogFolderSymlink, withDestinationPath: folder.path)
+    }
 
     private func beautifyLog(rawLogPath: String, logPath: String) async throws -> [String] {
         var tests: [String] = []


### PR DESCRIPTION
### Description
<!--Please describe your pull request.-->
- I've added creating a simlink to the latest logs folder;
- That should be useful to beautify `rawBuild.log` after using the `rugby build` command.

```yml
- name: Beautify logs
  if: always()
  run: cat ~/.rugby/logs/+latest/rawBuild.log 2>&1 | xcbeautify --renderer github-actions
```

| Messages in a pull request changes |
| ------------- |
| <img width="604" alt="Screenshot 2024-03-15 at 20 16 09" src="https://github.com/swiftyfinch/Rugby/assets/64660122/e07a2fc5-a7d4-47c5-91d3-31c7737dc212">  |
| <img width="738" alt="Screenshot 2024-03-15 at 20 16 18" src="https://github.com/swiftyfinch/Rugby/assets/64660122/af82feb7-7dde-4126-afc6-62514a020d30"> |

### References
<!--Provide links to an existing issue or external references/discussions, if appropriate.-->
- #357

### Checklist (I have ...)
- [x] 🧐 Followed the code style of the rest of the project
- [ ] 📖 Updated the documentation, if necessary
- [ ] 👨🏻‍🔧 Added at least one test which validates that my change is working, if appropriate
- [x] 👮🏻‍♂️ Run `make lint` and fixed all warnings
- [x] ✅ Run `make test` and fixed all tests

❤️ Thanks for contributing to the 🏈 Rugby!
