### PR TITLE
🚀 Implement ability to add headers in warmup command

### DIFF
--- a/Docs/commands-help/warmup.md
+++ b/Docs/commands-help/warmup.md
@@ -11,22 +11,23 @@
  > Download remote binaries for targets from Pods project.
 
  Arguments:
-╭─────────────────────────────────────────────────────────────────────────────╮
-│ endpoint  * Endpoint for your binaries storage (s3.eu-west-2.amazonaws.com) │
-╰─────────────────────────────────────────────────────────────────────────────╯
+╭──────────────────────────────────────────────────────────────────────────────╮
+│ endpoint  * Endpoint for your binaries storage (s3.eu-west-2.amazonaws.com). │
+╰──────────────────────────────────────────────────────────────────────────────╯
  Options:
-╭───────────────────────────────────────────────────────────────────────────────────╮
-│ -s, --sdk                  * Build SDK: sim or ios.                               │
-│ -a, --arch                 * Build architecture: auto, x86_64 or arm64.           │
-│ -c, --config               * Build configuration. (Debug)                         │
-│ -t, --targets []           * Target names to select. Empty means all targets.     │
-│ -g, --targets-as-regex []  * Regular expression patterns to select targets.       │
-│ -e, --except []            * Target names to exclude.                             │
-│ -x, --except-as-regex []   * Regular expression patterns to exclude targets.      │
-│ -o, --output               * Output mode: fold, multiline, silent, raw.           │
-│ --timeout                  * Timeout for requests in seconds. (60)                │
-│ --max-connections          * The maximum number of simultaneous connections. (10) │
-╰───────────────────────────────────────────────────────────────────────────────────╯
+╭────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ -s, --sdk                  * Build SDK: sim or ios.                                            │
+│ -a, --arch                 * Build architecture: auto, x86_64 or arm64.                        │
+│ -c, --config               * Build configuration. (Debug)                                      │
+│ -t, --targets []           * Target names to select. Empty means all targets.                  │
+│ -g, --targets-as-regex []  * Regular expression patterns to select targets.                    │
+│ -e, --except []            * Target names to exclude.                                          │
+│ -x, --except-as-regex []   * Regular expression patterns to exclude targets.                   │
+│ -o, --output               * Output mode: fold, multiline, silent, raw.                        │
+│ --timeout                  * Timeout for requests in seconds. (60)                             │
+│ --max-connections          * The maximum number of simultaneous connections. (10)              │
+│ --headers []               * Extra HTTP header fields for a request ("s3-key: my-secret-key"). │
+╰────────────────────────────────────────────────────────────────────────────────────────────────╯
  Flags:
 ╭─────────────────────────────────────────────────────────────────────────────────────────────╮
 │ --analyse         * Run only in analyse mode without downloading. The endpoint is optional. │

--- a/Sources/RugbyFoundation/Core/Warmup/CacheDownloader.swift
+++ b/Sources/RugbyFoundation/Core/Warmup/CacheDownloader.swift
@@ -4,8 +4,8 @@ import Foundation
 // MARK: - Interface
 
 protocol ICacheDownloader: AnyObject {
-    func checkIfBinaryIsReachable(url: URL) async -> Bool
-    func downloadBinary(url: URL, to folderURL: URL) async -> Bool
+    func checkIfBinaryIsReachable(url: URL, headers: [String: String]) async -> Bool
+    func downloadBinary(url: URL, headers: [String: String], to folderURL: URL) async -> Bool
 }
 
 // MARK: - Implementation
@@ -28,10 +28,13 @@ final class CacheDownloader: Loggable {
 
     // MARK: - Private
 
-    private func download(_ url: URL) async -> URL? {
+    private func download(_ url: URL, headers: [String: String]) async -> URL? {
         do {
             await log("Downloading \(url)", output: .file)
-            let urlRequest = URLRequest(url: url)
+            var urlRequest = URLRequest(url: url)
+            headers.forEach { field, value in
+                urlRequest.addValue(value, forHTTPHeaderField: field)
+            }
             return try await urlSession.download(for: urlRequest)
         } catch {
             await log("Failed downloading \(url):\n\(error.beautifulDescription)", output: .file)
@@ -53,12 +56,12 @@ final class CacheDownloader: Loggable {
 }
 
 extension CacheDownloader: ICacheDownloader {
-    func checkIfBinaryIsReachable(url: URL) async -> Bool {
-        (try? await reachabilityChecker.checkIfURLIsReachable(url)) == true
+    func checkIfBinaryIsReachable(url: URL, headers: [String: String]) async -> Bool {
+        (try? await reachabilityChecker.checkIfURLIsReachable(url, headers: headers)) == true
     }
 
-    func downloadBinary(url: URL, to folderURL: URL) async -> Bool {
-        guard let fileURL = await download(url) else { return false }
+    func downloadBinary(url: URL, headers: [String: String], to folderURL: URL) async -> Bool {
+        guard let fileURL = await download(url, headers: headers) else { return false }
         return await unzip(fileURL, to: folderURL)
     }
 }

--- a/Sources/RugbyFoundation/Core/Warmup/ReachabilityChecker.swift
+++ b/Sources/RugbyFoundation/Core/Warmup/ReachabilityChecker.swift
@@ -3,7 +3,7 @@ import Foundation
 // MARK: - Interface
 
 protocol IReachabilityChecker: AnyObject {
-    func checkIfURLIsReachable(_ url: URL) async throws -> Bool
+    func checkIfURLIsReachable(_ url: URL, headers: [String: String]) async throws -> Bool
 }
 
 enum ReachabilityCheckerError: LocalizedError, Equatable {
@@ -30,9 +30,12 @@ final class ReachabilityChecker {
 extension ReachabilityChecker: IReachabilityChecker {
     private typealias Error = ReachabilityCheckerError
 
-    func checkIfURLIsReachable(_ url: URL) async throws -> Bool {
+    func checkIfURLIsReachable(_ url: URL, headers: [String: String]) async throws -> Bool {
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = "HEAD"
+        headers.forEach { field, value in
+            urlRequest.addValue(value, forHTTPHeaderField: field)
+        }
         let (_, response) = try await urlSession.data(for: urlRequest)
         guard let httpResponse = (response as? HTTPURLResponse) else { throw Error.urlUnreachable(url) }
         return httpResponse.statusCode == 200

--- a/Tests/FoundationTests/Core/Warmup/CacheDownloaderTests.swift
+++ b/Tests/FoundationTests/Core/Warmup/CacheDownloaderTests.swift
@@ -52,28 +52,28 @@ final class CacheDownloaderTests: XCTestCase {
 extension CacheDownloaderTests {
     func test_checkIfBinaryIsReachable_true() async {
         let url: URL! = URL(string: "https://github.com/swiftyfinch/Rugby")
-        reachabilityChecker.checkIfURLIsReachableReturnValue = true
+        reachabilityChecker.checkIfURLIsReachableHeadersReturnValue = true
 
         // Act
-        let isReachable = await sut.checkIfBinaryIsReachable(url: url)
+        let isReachable = await sut.checkIfBinaryIsReachable(url: url, headers: [:])
 
         // Assert
         XCTAssertTrue(isReachable)
-        XCTAssertEqual(reachabilityChecker.checkIfURLIsReachableCallsCount, 1)
-        XCTAssertEqual(reachabilityChecker.checkIfURLIsReachableReceivedUrl, url)
+        XCTAssertEqual(reachabilityChecker.checkIfURLIsReachableHeadersCallsCount, 1)
+        XCTAssertEqual(reachabilityChecker.checkIfURLIsReachableHeadersReceivedArguments?.url, url)
     }
 
     func test_checkIfBinaryIsReachable_false() async {
         let url: URL! = URL(string: "https://github.com/swiftyfinch/Rugby")
-        reachabilityChecker.checkIfURLIsReachableReturnValue = false
+        reachabilityChecker.checkIfURLIsReachableHeadersReturnValue = false
 
         // Act
-        let isReachable = await sut.checkIfBinaryIsReachable(url: url)
+        let isReachable = await sut.checkIfBinaryIsReachable(url: url, headers: [:])
 
         // Assert
         XCTAssertFalse(isReachable)
-        XCTAssertEqual(reachabilityChecker.checkIfURLIsReachableCallsCount, 1)
-        XCTAssertEqual(reachabilityChecker.checkIfURLIsReachableReceivedUrl, url)
+        XCTAssertEqual(reachabilityChecker.checkIfURLIsReachableHeadersCallsCount, 1)
+        XCTAssertEqual(reachabilityChecker.checkIfURLIsReachableHeadersReceivedArguments?.url, url)
     }
 
     func test_downloadBinary_failedDownloading() async {
@@ -84,12 +84,14 @@ extension CacheDownloaderTests {
         urlSession.downloadForThrowableError = TestError.test
 
         // Act
-        let isDownloaded = await sut.downloadBinary(url: url, to: fileURL)
+        let isDownloaded = await sut.downloadBinary(url: url, headers: ["test_field": "test_value"], to: fileURL)
 
         // Assert
         XCTAssertFalse(isDownloaded)
         XCTAssertEqual(urlSession.downloadForCallsCount, 1)
         XCTAssertEqual(urlSession.downloadForReceivedRequest?.url, url)
+        XCTAssertEqual(urlSession.downloadForReceivedRequest?.allHTTPHeaderFields?.count, 1)
+        XCTAssertEqual(urlSession.downloadForReceivedRequest?.allHTTPHeaderFields?["test_field"], "test_value")
         XCTAssertEqual(logger.logLevelOutputReceivedInvocations.count, 2)
         XCTAssertEqual(
             logger.logLevelOutputReceivedInvocations[0].text,
@@ -116,7 +118,7 @@ extension CacheDownloaderTests {
         decompressor.unzipFileDestinationThrowableError = TestError.test
 
         // Act
-        let isDownloaded = await sut.downloadBinary(url: url, to: fileURL)
+        let isDownloaded = await sut.downloadBinary(url: url, headers: [:], to: fileURL)
 
         // Assert
         XCTAssertFalse(isDownloaded)
@@ -159,7 +161,7 @@ extension CacheDownloaderTests {
         fishSharedStorage.createFolderAtReturnValue = IFolderMock()
 
         // Act
-        let isDownloaded = await sut.downloadBinary(url: url, to: fileURL)
+        let isDownloaded = await sut.downloadBinary(url: url, headers: [:], to: fileURL)
 
         // Assert
         XCTAssertTrue(isDownloaded)

--- a/Tests/FoundationTests/Core/Warmup/ReachabilityCheckerTests.swift
+++ b/Tests/FoundationTests/Core/Warmup/ReachabilityCheckerTests.swift
@@ -26,13 +26,15 @@ extension ReachabilityCheckerTests {
         urlSession.dataForReturnValue = (data, response)
 
         // Act
-        let reachable = try await sut.checkIfURLIsReachable(url)
+        let reachable = try await sut.checkIfURLIsReachable(url, headers: ["test_field": "test_value"])
 
         // Assert
         XCTAssertTrue(reachable)
         XCTAssertEqual(urlSession.dataForCallsCount, 1)
         XCTAssertEqual(urlSession.dataForReceivedRequest?.url, url)
         XCTAssertEqual(urlSession.dataForReceivedRequest?.httpMethod, "HEAD")
+        XCTAssertEqual(urlSession.dataForReceivedRequest?.allHTTPHeaderFields?.count, 1)
+        XCTAssertEqual(urlSession.dataForReceivedRequest?.allHTTPHeaderFields?["test_field"], "test_value")
     }
 
     func test_checkIfURLIsReachable_404() async throws {
@@ -42,7 +44,7 @@ extension ReachabilityCheckerTests {
         urlSession.dataForReturnValue = (data, response)
 
         // Act
-        let reachable = try await sut.checkIfURLIsReachable(url)
+        let reachable = try await sut.checkIfURLIsReachable(url, headers: [:])
 
         // Assert
         XCTAssertFalse(reachable)
@@ -60,7 +62,7 @@ extension ReachabilityCheckerTests {
         // Act
         var resultError: Error?
         do {
-            _ = try await sut.checkIfURLIsReachable(url)
+            _ = try await sut.checkIfURLIsReachable(url, headers: [:])
         } catch {
             resultError = error
         }

--- a/Tests/FoundationTests/Core/Warmup/WarmupManagerTests.swift
+++ b/Tests/FoundationTests/Core/Warmup/WarmupManagerTests.swift
@@ -72,7 +72,8 @@ extension WarmupManagerTests {
                 targetsRegex: nil,
                 exceptTargetsRegex: nil,
                 options: .mock(),
-                maxInParallel: 10
+                maxInParallel: 10,
+                headers: [:]
             )
         } catch {
             resultError = error
@@ -94,7 +95,8 @@ extension WarmupManagerTests {
                 targetsRegex: nil,
                 exceptTargetsRegex: nil,
                 options: .mock(),
-                maxInParallel: 10
+                maxInParallel: 10,
+                headers: [:]
             )
         } catch {
             resultError = error
@@ -116,7 +118,8 @@ extension WarmupManagerTests {
                 targetsRegex: nil,
                 exceptTargetsRegex: nil,
                 options: .mock(),
-                maxInParallel: 10
+                maxInParallel: 10,
+                headers: [:]
             )
         } catch {
             resultError = error
@@ -154,7 +157,8 @@ extension WarmupManagerTests {
             targetsRegex: targetsRegex,
             exceptTargetsRegex: exceptTargetsRegex,
             options: xcodeBuildOptions,
-            maxInParallel: 10
+            maxInParallel: 10,
+            headers: [:]
         )
 
         // Assert
@@ -238,7 +242,8 @@ extension WarmupManagerTests {
             targetsRegex: targetsRegex,
             exceptTargetsRegex: exceptTargetsRegex,
             options: xcodeBuildOptions,
-            maxInParallel: 10
+            maxInParallel: 10,
+            headers: [:]
         )
 
         // Assert
@@ -342,7 +347,7 @@ extension WarmupManagerTests {
             default: fatalError()
             }
         }
-        cacheDownloader.checkIfBinaryIsReachableUrlClosure = { url in
+        cacheDownloader.checkIfBinaryIsReachableUrlHeadersClosure = { url, _ in
             switch url.absoluteString {
             case "https://s3.eu-west-2.amazonaws.com/SnapKit/Debug-iphonesimulator-arm64/eb56c2f.zip":
                 return true
@@ -358,7 +363,8 @@ extension WarmupManagerTests {
             targetsRegex: targetsRegex,
             exceptTargetsRegex: exceptTargetsRegex,
             options: xcodeBuildOptions,
-            maxInParallel: 10
+            maxInParallel: 10,
+            headers: [:]
         )
 
         // Assert
@@ -419,16 +425,15 @@ extension WarmupManagerTests {
         XCTAssertEqual(logger.logLevelOutputReceivedInvocations[1].level, .result)
         XCTAssertEqual(logger.logLevelOutputReceivedInvocations[1].output, .all)
 
-        XCTAssertEqual(cacheDownloader.checkIfBinaryIsReachableUrlReceivedInvocations.count, 2)
-        let checkIfBinaryIsReachableInvocations = cacheDownloader.checkIfBinaryIsReachableUrlReceivedInvocations.sorted(
-            by: { $0.absoluteString < $1.absoluteString }
-        )
+        let reachableInvocations = try XCTUnwrap(cacheDownloader.checkIfBinaryIsReachableUrlHeadersReceivedInvocations)
+        XCTAssertEqual(reachableInvocations.count, 2)
+        let sortedReachableInvocations = reachableInvocations.sorted { $0.url.absoluteString < $1.url.absoluteString }
         XCTAssertEqual(
-            checkIfBinaryIsReachableInvocations[0].absoluteString,
+            sortedReachableInvocations[0].url.absoluteString,
             "https://s3.eu-west-2.amazonaws.com/Alamofire/Debug-iphonesimulator-arm64/dbe4415.zip"
         )
         XCTAssertEqual(
-            checkIfBinaryIsReachableInvocations[1].absoluteString,
+            sortedReachableInvocations[1].url.absoluteString,
             "https://s3.eu-west-2.amazonaws.com/SnapKit/Debug-iphonesimulator-arm64/eb56c2f.zip"
         )
         XCTAssertEqual(loggerBlockInvocations[3].header, "Checking binaries reachability")
@@ -509,7 +514,7 @@ extension WarmupManagerTests {
             default: fatalError()
             }
         }
-        cacheDownloader.checkIfBinaryIsReachableUrlClosure = { url in
+        cacheDownloader.checkIfBinaryIsReachableUrlHeadersClosure = { url, _ in
             switch url.absoluteString {
             case "https://s3.eu-west-2.amazonaws.com/SnapKit/Debug-iphonesimulator-arm64/eb56c2f.zip":
                 return true
@@ -520,7 +525,7 @@ extension WarmupManagerTests {
             default: fatalError()
             }
         }
-        cacheDownloader.downloadBinaryUrlToClosure = { url, _ in
+        cacheDownloader.downloadBinaryUrlHeadersToClosure = { url, _, _ in
             switch url.absoluteString {
             case "https://s3.eu-west-2.amazonaws.com/LocalPod/Debug-iphonesimulator-arm64/b3035c7.zip":
                 return true
@@ -536,7 +541,8 @@ extension WarmupManagerTests {
             targetsRegex: targetsRegex,
             exceptTargetsRegex: exceptTargetsRegex,
             options: xcodeBuildOptions,
-            maxInParallel: 10
+            maxInParallel: 10,
+            headers: ["test_field": "test_value"]
         )
 
         // Assert
@@ -600,22 +606,24 @@ extension WarmupManagerTests {
         XCTAssertEqual(logger.logLevelOutputReceivedInvocations[1].level, .result)
         XCTAssertEqual(logger.logLevelOutputReceivedInvocations[1].output, .all)
 
-        XCTAssertEqual(cacheDownloader.checkIfBinaryIsReachableUrlReceivedInvocations.count, 3)
-        let checkIfBinaryIsReachableInvocations = cacheDownloader.checkIfBinaryIsReachableUrlReceivedInvocations.sorted(
-            by: { $0.absoluteString < $1.absoluteString }
-        )
+        let reachableInvocations = try XCTUnwrap(cacheDownloader.checkIfBinaryIsReachableUrlHeadersReceivedInvocations)
+        XCTAssertEqual(reachableInvocations.count, 3)
+        let sortedReachableInvocations = reachableInvocations.sorted { $0.url.absoluteString < $1.url.absoluteString }
         XCTAssertEqual(
-            checkIfBinaryIsReachableInvocations[0].absoluteString,
+            sortedReachableInvocations[0].url.absoluteString,
             "https://s3.eu-west-2.amazonaws.com/Alamofire/Debug-iphonesimulator-arm64/dbe4415.zip"
         )
+        XCTAssertEqual(sortedReachableInvocations[0].headers, ["test_field": "test_value"])
         XCTAssertEqual(
-            checkIfBinaryIsReachableInvocations[1].absoluteString,
+            sortedReachableInvocations[1].url.absoluteString,
             "https://s3.eu-west-2.amazonaws.com/LocalPod/Debug-iphonesimulator-arm64/b3035c7.zip"
         )
+        XCTAssertEqual(sortedReachableInvocations[1].headers, ["test_field": "test_value"])
         XCTAssertEqual(
-            checkIfBinaryIsReachableInvocations[2].absoluteString,
+            sortedReachableInvocations[2].url.absoluteString,
             "https://s3.eu-west-2.amazonaws.com/SnapKit/Debug-iphonesimulator-arm64/eb56c2f.zip"
         )
+        XCTAssertEqual(sortedReachableInvocations[2].headers, ["test_field": "test_value"])
         XCTAssertEqual(loggerBlockInvocations[3].header, "Checking binaries reachability")
         XCTAssertNil(loggerBlockInvocations[3].footer)
         XCTAssertNil(loggerBlockInvocations[3].metricKey)
@@ -637,6 +645,17 @@ extension WarmupManagerTests {
         XCTAssertEqual(metricsLogger.logNameReceivedInvocations[0].metric, 66.0)
         XCTAssertEqual(metricsLogger.logNameReceivedInvocations[1].name, "Downloaded Binaries Percent")
         XCTAssertEqual(metricsLogger.logNameReceivedInvocations[1].metric, 50.0)
+
+        let downloadBinaryInvocations = cacheDownloader.downloadBinaryUrlHeadersToReceivedInvocations.sorted {
+            $0.url.absoluteString < $1.url.absoluteString
+        }
+        XCTAssertEqual(downloadBinaryInvocations.count, 2)
+        XCTAssertEqual(downloadBinaryInvocations[0].url.absoluteString,
+                       "https://s3.eu-west-2.amazonaws.com/LocalPod/Debug-iphonesimulator-arm64/b3035c7.zip")
+        XCTAssertEqual(downloadBinaryInvocations[0].headers, ["test_field": "test_value"])
+        XCTAssertEqual(downloadBinaryInvocations[1].url.absoluteString,
+                       "https://s3.eu-west-2.amazonaws.com/SnapKit/Debug-iphonesimulator-arm64/eb56c2f.zip")
+        XCTAssertEqual(downloadBinaryInvocations[1].headers, ["test_field": "test_value"])
 
         XCTAssertEqual(logger.logLevelOutputReceivedInvocations[3].text, "Found Remotely: 66% (2/3)")
         XCTAssertEqual(logger.logLevelOutputReceivedInvocations[3].level, .compact)

--- a/Tests/FoundationTests/Mocks/ICacheDownloaderMock.generated.swift
+++ b/Tests/FoundationTests/Mocks/ICacheDownloaderMock.generated.swift
@@ -10,47 +10,47 @@ final class ICacheDownloaderMock: ICacheDownloader {
 
     // MARK: - checkIfBinaryIsReachable
 
-    var checkIfBinaryIsReachableUrlCallsCount = 0
-    var checkIfBinaryIsReachableUrlCalled: Bool { checkIfBinaryIsReachableUrlCallsCount > 0 }
-    var checkIfBinaryIsReachableUrlReceivedUrl: URL?
-    var checkIfBinaryIsReachableUrlReceivedInvocations: [URL] = []
-    private let checkIfBinaryIsReachableUrlReceivedInvocationsLock = NSRecursiveLock()
-    var checkIfBinaryIsReachableUrlReturnValue: Bool!
-    var checkIfBinaryIsReachableUrlClosure: ((URL) async -> Bool)?
+    var checkIfBinaryIsReachableUrlHeadersCallsCount = 0
+    var checkIfBinaryIsReachableUrlHeadersCalled: Bool { checkIfBinaryIsReachableUrlHeadersCallsCount > 0 }
+    var checkIfBinaryIsReachableUrlHeadersReceivedArguments: (url: URL, headers: [String: String])?
+    var checkIfBinaryIsReachableUrlHeadersReceivedInvocations: [(url: URL, headers: [String: String])] = []
+    private let checkIfBinaryIsReachableUrlHeadersReceivedInvocationsLock = NSRecursiveLock()
+    var checkIfBinaryIsReachableUrlHeadersReturnValue: Bool!
+    var checkIfBinaryIsReachableUrlHeadersClosure: ((URL, [String: String]) async -> Bool)?
 
-    func checkIfBinaryIsReachable(url: URL) async -> Bool {
-        checkIfBinaryIsReachableUrlCallsCount += 1
-        checkIfBinaryIsReachableUrlReceivedUrl = url
-        checkIfBinaryIsReachableUrlReceivedInvocationsLock.withLock {
-            checkIfBinaryIsReachableUrlReceivedInvocations.append(url)
+    func checkIfBinaryIsReachable(url: URL, headers: [String: String]) async -> Bool {
+        checkIfBinaryIsReachableUrlHeadersCallsCount += 1
+        checkIfBinaryIsReachableUrlHeadersReceivedArguments = (url: url, headers: headers)
+        checkIfBinaryIsReachableUrlHeadersReceivedInvocationsLock.withLock {
+            checkIfBinaryIsReachableUrlHeadersReceivedInvocations.append((url: url, headers: headers))
         }
-        if let checkIfBinaryIsReachableUrlClosure = checkIfBinaryIsReachableUrlClosure {
-            return await checkIfBinaryIsReachableUrlClosure(url)
+        if let checkIfBinaryIsReachableUrlHeadersClosure = checkIfBinaryIsReachableUrlHeadersClosure {
+            return await checkIfBinaryIsReachableUrlHeadersClosure(url, headers)
         } else {
-            return checkIfBinaryIsReachableUrlReturnValue
+            return checkIfBinaryIsReachableUrlHeadersReturnValue
         }
     }
 
     // MARK: - downloadBinary
 
-    var downloadBinaryUrlToCallsCount = 0
-    var downloadBinaryUrlToCalled: Bool { downloadBinaryUrlToCallsCount > 0 }
-    var downloadBinaryUrlToReceivedArguments: (url: URL, folderURL: URL)?
-    var downloadBinaryUrlToReceivedInvocations: [(url: URL, folderURL: URL)] = []
-    private let downloadBinaryUrlToReceivedInvocationsLock = NSRecursiveLock()
-    var downloadBinaryUrlToReturnValue: Bool!
-    var downloadBinaryUrlToClosure: ((URL, URL) async -> Bool)?
+    var downloadBinaryUrlHeadersToCallsCount = 0
+    var downloadBinaryUrlHeadersToCalled: Bool { downloadBinaryUrlHeadersToCallsCount > 0 }
+    var downloadBinaryUrlHeadersToReceivedArguments: (url: URL, headers: [String: String], folderURL: URL)?
+    var downloadBinaryUrlHeadersToReceivedInvocations: [(url: URL, headers: [String: String], folderURL: URL)] = []
+    private let downloadBinaryUrlHeadersToReceivedInvocationsLock = NSRecursiveLock()
+    var downloadBinaryUrlHeadersToReturnValue: Bool!
+    var downloadBinaryUrlHeadersToClosure: ((URL, [String: String], URL) async -> Bool)?
 
-    func downloadBinary(url: URL, to folderURL: URL) async -> Bool {
-        downloadBinaryUrlToCallsCount += 1
-        downloadBinaryUrlToReceivedArguments = (url: url, folderURL: folderURL)
-        downloadBinaryUrlToReceivedInvocationsLock.withLock {
-            downloadBinaryUrlToReceivedInvocations.append((url: url, folderURL: folderURL))
+    func downloadBinary(url: URL, headers: [String: String], to folderURL: URL) async -> Bool {
+        downloadBinaryUrlHeadersToCallsCount += 1
+        downloadBinaryUrlHeadersToReceivedArguments = (url: url, headers: headers, folderURL: folderURL)
+        downloadBinaryUrlHeadersToReceivedInvocationsLock.withLock {
+            downloadBinaryUrlHeadersToReceivedInvocations.append((url: url, headers: headers, folderURL: folderURL))
         }
-        if let downloadBinaryUrlToClosure = downloadBinaryUrlToClosure {
-            return await downloadBinaryUrlToClosure(url, folderURL)
+        if let downloadBinaryUrlHeadersToClosure = downloadBinaryUrlHeadersToClosure {
+            return await downloadBinaryUrlHeadersToClosure(url, headers, folderURL)
         } else {
-            return downloadBinaryUrlToReturnValue
+            return downloadBinaryUrlHeadersToReturnValue
         }
     }
 }

--- a/Tests/FoundationTests/Mocks/IReachabilityCheckerMock.generated.swift
+++ b/Tests/FoundationTests/Mocks/IReachabilityCheckerMock.generated.swift
@@ -10,28 +10,28 @@ final class IReachabilityCheckerMock: IReachabilityChecker {
 
     // MARK: - checkIfURLIsReachable
 
-    var checkIfURLIsReachableThrowableError: Error?
-    var checkIfURLIsReachableCallsCount = 0
-    var checkIfURLIsReachableCalled: Bool { checkIfURLIsReachableCallsCount > 0 }
-    var checkIfURLIsReachableReceivedUrl: URL?
-    var checkIfURLIsReachableReceivedInvocations: [URL] = []
-    private let checkIfURLIsReachableReceivedInvocationsLock = NSRecursiveLock()
-    var checkIfURLIsReachableReturnValue: Bool!
-    var checkIfURLIsReachableClosure: ((URL) async throws -> Bool)?
+    var checkIfURLIsReachableHeadersThrowableError: Error?
+    var checkIfURLIsReachableHeadersCallsCount = 0
+    var checkIfURLIsReachableHeadersCalled: Bool { checkIfURLIsReachableHeadersCallsCount > 0 }
+    var checkIfURLIsReachableHeadersReceivedArguments: (url: URL, headers: [String: String])?
+    var checkIfURLIsReachableHeadersReceivedInvocations: [(url: URL, headers: [String: String])] = []
+    private let checkIfURLIsReachableHeadersReceivedInvocationsLock = NSRecursiveLock()
+    var checkIfURLIsReachableHeadersReturnValue: Bool!
+    var checkIfURLIsReachableHeadersClosure: ((URL, [String: String]) async throws -> Bool)?
 
-    func checkIfURLIsReachable(_ url: URL) async throws -> Bool {
-        checkIfURLIsReachableCallsCount += 1
-        checkIfURLIsReachableReceivedUrl = url
-        checkIfURLIsReachableReceivedInvocationsLock.withLock {
-            checkIfURLIsReachableReceivedInvocations.append(url)
+    func checkIfURLIsReachable(_ url: URL, headers: [String: String]) async throws -> Bool {
+        checkIfURLIsReachableHeadersCallsCount += 1
+        checkIfURLIsReachableHeadersReceivedArguments = (url: url, headers: headers)
+        checkIfURLIsReachableHeadersReceivedInvocationsLock.withLock {
+            checkIfURLIsReachableHeadersReceivedInvocations.append((url: url, headers: headers))
         }
-        if let error = checkIfURLIsReachableThrowableError {
+        if let error = checkIfURLIsReachableHeadersThrowableError {
             throw error
         }
-        if let checkIfURLIsReachableClosure = checkIfURLIsReachableClosure {
-            return try await checkIfURLIsReachableClosure(url)
+        if let checkIfURLIsReachableHeadersClosure = checkIfURLIsReachableHeadersClosure {
+            return try await checkIfURLIsReachableHeadersClosure(url, headers)
         } else {
-            return checkIfURLIsReachableReturnValue
+            return checkIfURLIsReachableHeadersReturnValue
         }
     }
 }

--- a/Tests/RugbyTests/Commands/Basic/WarmupTests.swift
+++ b/Tests/RugbyTests/Commands/Basic/WarmupTests.swift
@@ -1,0 +1,20 @@
+@testable import Rugby
+import XCTest
+
+final class WarmupTests: XCTestCase {
+    func test_headersParsing_two() {
+        let headers = ["X-First-Name: Joe", "User-Agent: yes-please/2000"].parseHeaders()
+
+        // Assert
+        XCTAssertEqual(headers.count, 2)
+        XCTAssertEqual(headers["X-First-Name"], "Joe")
+        XCTAssertEqual(headers["User-Agent"], "yes-please/2000")
+    }
+
+    func test_headersParsing() {
+        XCTAssertEqual(["User-Agent: yes-please/2000"].parseHeaders(), ["User-Agent": "yes-please/2000"])
+        XCTAssertEqual(["User-Agent:yes-please/2000"].parseHeaders(), [:])
+        XCTAssertEqual([].parseHeaders(), [:])
+        XCTAssertEqual([""].parseHeaders(), [:])
+    }
+}


### PR DESCRIPTION
### Description
<!--Please describe your pull request.-->
You can find a description in #329.

###### New API example:
```sh
> rugby warmup "some_binaries_endpoint" --headers "X-JFrog-Art-Api: my-api-key"
```

### Checklist (I have ...)
- [x] 🧐 Followed the code style of the rest of the project
- [x] 📖 Updated the documentation, if necessary
- [x] 👨🏻‍🔧 Added at least one test which validates that my change is working, if appropriate
- [x] 👮🏻‍♂️ Run `make lint` and fixed all warnings
- [x] ✅ Run `make test` and fixed all tests

❤️ Thanks for contributing to the 🏈 Rugby!
