### PR TITLE
🚀 Added detaching XCFramework phase to separate target

### DIFF
--- a/Sources/RugbyFoundation/Core/Build/BuildTargetsManager.swift
+++ b/Sources/RugbyFoundation/Core/Build/BuildTargetsManager.swift
@@ -75,7 +75,10 @@ extension BuildTargetsManager: IBuildTargetsManager {
         buildConfiguration: String?,
         testplanPath: String?
     ) async throws -> IInternalTarget {
-        let target = try await xcodeProject.createAggregatedTarget(name: buildTargetName, dependencies: dependencies)
+        let target = try await xcodeProject.createAggregatedTargetInRootProject(
+            name: buildTargetName,
+            dependencies: dependencies
+        )
         if let buildConfiguration, let testplanPath {
             xcodeProject.createTestingScheme(target, buildConfiguration: buildConfiguration, testplanPath: testplanPath)
         }

--- a/Sources/RugbyFoundation/Core/Use/XCFrameworksPatcher.swift
+++ b/Sources/RugbyFoundation/Core/Use/XCFrameworksPatcher.swift
@@ -1,0 +1,45 @@
+// MARK: - Interface
+
+protocol IXCFrameworksPatcher: AnyObject {
+    func detachXCFrameworkBuildPhase(from targets: TargetsMap) async throws
+}
+
+// MARK: - Implementation
+
+final class XCFrameworksPatcher {
+    private let xcodeProject: IInternalXcodeProject
+    private let xcodePhaseEditor: IXcodePhaseEditor
+    private let xcodeBuildConfigurationEditor: IXcodeBuildConfigurationEditor
+
+    init(xcodeProject: IInternalXcodeProject,
+         xcodePhaseEditor: IXcodePhaseEditor,
+         xcodeBuildConfigurationEditor: IXcodeBuildConfigurationEditor) {
+        self.xcodeProject = xcodeProject
+        self.xcodePhaseEditor = xcodePhaseEditor
+        self.xcodeBuildConfigurationEditor = xcodeBuildConfigurationEditor
+    }
+}
+
+// MARK: - IXCFrameworksPatcher
+
+extension XCFrameworksPatcher: IXCFrameworksPatcher {
+    func detachXCFrameworkBuildPhase(from targets: TargetsMap) async throws {
+        let xcframeworkScriptTargets = xcodePhaseEditor.filterXCFrameworksPhaseTargets(targets)
+        for target in xcframeworkScriptTargets.values {
+            let xcframeworkTarget = try await xcodeProject.createAggregatedTarget(
+                name: "\(target.name)\(String.xcframeworkSuffix)",
+                in: target.project
+            )
+            xcodePhaseEditor.copyXCFrameworksPhase(from: target, to: xcframeworkTarget)
+            xcodeBuildConfigurationEditor.copyBuildConfigurationList(from: target, to: xcframeworkTarget)
+            try xcodeProject.addDependencies([xcframeworkTarget.uuid: xcframeworkTarget], to: target)
+        }
+        if xcframeworkScriptTargets.isNotEmpty {
+            try await xcodeProject.save()
+        }
+    }
+}
+
+private extension String {
+    static let xcframeworkSuffix = "-XCFramework"
+}

--- a/Sources/RugbyFoundation/Vault/Commands/Vault+Use.swift
+++ b/Sources/RugbyFoundation/Vault/Commands/Vault+Use.swift
@@ -10,16 +10,23 @@ extension Vault {
 
     func internalUseBinariesManager(xcodeProject: IInternalXcodeProject,
                                     buildTargetsManager: IBuildTargetsManager) -> IInternalUseBinariesManager {
-        UseBinariesManager(logger: logger,
-                           buildTargetsManager: buildTargetsManager,
-                           librariesPatcher: LibrariesPatcher(logger: logger),
-                           xcodeProject: xcodeProject,
-                           rugbyXcodeProject: RugbyXcodeProject(xcodeProject: xcodeProject),
-                           backupManager: backupManager(),
-                           binariesStorage: binariesStorage,
-                           targetsHasher: targetsHasher(),
-                           supportFilesPatcher: SupportFilesPatcher(),
-                           fileContentEditor: FileContentEditor(),
-                           targetsPrinter: targetsPrinter)
+        UseBinariesManager(
+            logger: logger,
+            buildTargetsManager: buildTargetsManager,
+            librariesPatcher: LibrariesPatcher(logger: logger),
+            xcodeProject: xcodeProject,
+            rugbyXcodeProject: RugbyXcodeProject(xcodeProject: xcodeProject),
+            backupManager: backupManager(),
+            binariesStorage: binariesStorage,
+            targetsHasher: targetsHasher(),
+            supportFilesPatcher: SupportFilesPatcher(),
+            fileContentEditor: FileContentEditor(),
+            targetsPrinter: targetsPrinter,
+            xcframeworksPatcher: XCFrameworksPatcher(
+                xcodeProject: xcodeProject,
+                xcodePhaseEditor: XcodePhaseEditor(),
+                xcodeBuildConfigurationEditor: XcodeBuildConfigurationEditor()
+            )
+        )
     }
 }

--- a/Sources/RugbyFoundation/XcodeProject/Services/XcodeBuildConfigurationEditor.swift
+++ b/Sources/RugbyFoundation/XcodeProject/Services/XcodeBuildConfigurationEditor.swift
@@ -1,0 +1,35 @@
+import XcodeProj
+
+// MARK: - Inteface
+
+protocol IXcodeBuildConfigurationEditor: AnyObject {
+    func copyBuildConfigurationList(from target: IInternalTarget, to destinationTarget: IInternalTarget)
+}
+
+// MARK: - Implemented
+
+final class XcodeBuildConfigurationEditor {}
+
+// MARK: - IXcodeBuildConfigurationEditor
+
+extension XcodeBuildConfigurationEditor: IXcodeBuildConfigurationEditor {
+    func copyBuildConfigurationList(from target: IInternalTarget, to destinationTarget: IInternalTarget) {
+        let buildConfigurations = target.pbxTarget.buildConfigurationList?.buildConfigurations.map {
+            XCBuildConfiguration(
+                name: $0.name,
+                baseConfiguration: $0.baseConfiguration,
+                buildSettings: $0.buildSettings
+            )
+        } ?? []
+        let buildConfigurationList = target.pbxTarget.buildConfigurationList.map {
+            XCConfigurationList(
+                buildConfigurations: buildConfigurations,
+                defaultConfigurationName: $0.defaultConfigurationName,
+                defaultConfigurationIsVisible: $0.defaultConfigurationIsVisible
+            )
+        }
+        buildConfigurationList?.buildConfigurations.forEach(destinationTarget.project.pbxProj.add(object:))
+        buildConfigurationList.map(destinationTarget.project.pbxProj.add(object:))
+        destinationTarget.pbxTarget.buildConfigurationList = buildConfigurationList
+    }
+}

--- a/Sources/RugbyFoundation/XcodeProject/Services/XcodeTargetsEditor.swift
+++ b/Sources/RugbyFoundation/XcodeProject/Services/XcodeTargetsEditor.swift
@@ -1,5 +1,19 @@
 import XcodeProj
 
+// MARK: - Interface
+
+protocol IXcodeTargetsEditor: AnyObject {
+    func resetCache()
+    func createAggregatedTarget(
+        name: String,
+        in project: IProject,
+        dependencies: TargetsMap
+    ) async throws -> IInternalTarget
+    func deleteTargets(_ targetsForRemove: TargetsMap, keepGroups: Bool) async throws
+}
+
+// MARK: - Implementation
+
 final class XcodeTargetsEditor: Loggable {
     let logger: ILogger
 
@@ -16,13 +30,20 @@ final class XcodeTargetsEditor: Loggable {
         self.targetsDataSource = targetsDataSource
         self.schemesEditor = schemesEditor
     }
+}
 
+// MARK: - IXcodeTargetsEditor
+
+extension XcodeTargetsEditor: IXcodeTargetsEditor {
     func resetCache() {
         targetsDataSource.resetCache()
     }
 
-    func createAggregatedTarget(name: String, dependencies: TargetsMap) async throws -> IInternalTarget {
-        let project = try await projectDataSource.rootProject
+    func createAggregatedTarget(
+        name: String,
+        in project: IProject,
+        dependencies: TargetsMap
+    ) async throws -> IInternalTarget {
         let pbxTarget = PBXAggregateTarget(name: name)
         pbxTarget.buildConfigurationList = try project.buildConfigurationList
         try project.pbxProject.targets.append(pbxTarget)

--- a/Sources/RugbyFoundation/XcodeProject/Services/XcodeTargetsEditor.swift
+++ b/Sources/RugbyFoundation/XcodeProject/Services/XcodeTargetsEditor.swift
@@ -10,6 +10,7 @@ protocol IXcodeTargetsEditor: AnyObject {
         dependencies: TargetsMap
     ) async throws -> IInternalTarget
     func deleteTargets(_ targetsForRemove: TargetsMap, keepGroups: Bool) async throws
+    func addDependencies(_ dependencies: TargetsMap, to target: IInternalTarget) throws
 }
 
 // MARK: - Implementation
@@ -107,5 +108,11 @@ extension XcodeTargetsEditor: IXcodeTargetsEditor {
 
         try await schemesEditor.deleteSchemes(ofTargets: targetsForRemove,
                                               targets: targetsDataSource.targets)
+    }
+
+    func addDependencies(_ dependencies: TargetsMap, to target: IInternalTarget) throws {
+        try target.project.pbxProj.addDependencies(dependencies, target: target)
+        target.addDependencies(dependencies)
+        target.resetDependencies()
     }
 }

--- a/Sources/RugbyFoundation/XcodeProject/XcodeProject.swift
+++ b/Sources/RugbyFoundation/XcodeProject/XcodeProject.swift
@@ -35,6 +35,11 @@ protocol IInternalXcodeProject: IXcodeProject {
         keepGroups: Bool
     ) async throws
 
+    func addDependencies(
+        _ dependencies: TargetsMap,
+        to target: IInternalTarget
+    ) throws
+
     func createTestingScheme(
         _ target: IInternalTarget,
         buildConfiguration: String,
@@ -150,6 +155,15 @@ extension XcodeProject: IInternalXcodeProject {
 
     func deleteTargets(_ targetsForRemove: TargetsMap, keepGroups: Bool = true) async throws {
         try await targetsEditor.deleteTargets(targetsForRemove, keepGroups: keepGroups)
+    }
+
+    // MARK: - Dependencies
+
+    func addDependencies(
+        _ dependencies: TargetsMap,
+        to target: IInternalTarget
+    ) throws {
+        try targetsEditor.addDependencies(dependencies, to: target)
     }
 
     // MARK: - Create Schemes

--- a/Tests/FoundationTests/Core/Build/BuildTargetsManagerTests.swift
+++ b/Tests/FoundationTests/Core/Build/BuildTargetsManagerTests.swift
@@ -196,15 +196,15 @@ extension BuildTargetsManagerTests {
             snapkit.uuid: snapkit
         ]
         let resultTarget = IInternalTargetMock()
-        xcodeProject.createAggregatedTargetNameDependenciesReturnValue = resultTarget
+        xcodeProject.createAggregatedTargetInRootProjectNameDependenciesReturnValue = resultTarget
 
         // Act
         let target = try await sut.createTarget(dependencies: targets)
 
         // Assert
         XCTAssertIdentical(resultTarget, target)
-        XCTAssertEqual(xcodeProject.createAggregatedTargetNameDependenciesCallsCount, 1)
-        let arguments = try XCTUnwrap(xcodeProject.createAggregatedTargetNameDependenciesReceivedArguments)
+        XCTAssertEqual(xcodeProject.createAggregatedTargetInRootProjectNameDependenciesCallsCount, 1)
+        let arguments = try XCTUnwrap(xcodeProject.createAggregatedTargetInRootProjectNameDependenciesReceivedArguments)
         XCTAssertEqual(arguments.name, "RugbyPods")
         XCTAssertEqual(arguments.dependencies.count, 3)
         XCTAssertTrue(arguments.dependencies.contains(alamofire.uuid))
@@ -222,7 +222,7 @@ extension BuildTargetsManagerTests {
             localPodTests.uuid: localPodTests
         ]
         let resultTarget = IInternalTargetMock()
-        xcodeProject.createAggregatedTargetNameDependenciesReturnValue = resultTarget
+        xcodeProject.createAggregatedTargetInRootProjectNameDependenciesReturnValue = resultTarget
 
         // Act
         let target = try await sut.createTarget(
@@ -233,9 +233,9 @@ extension BuildTargetsManagerTests {
 
         // Assert
         XCTAssertIdentical(resultTarget, target)
-        XCTAssertEqual(xcodeProject.createAggregatedTargetNameDependenciesCallsCount, 1)
+        XCTAssertEqual(xcodeProject.createAggregatedTargetInRootProjectNameDependenciesCallsCount, 1)
         let createAggregatedArguments = try XCTUnwrap(
-            xcodeProject.createAggregatedTargetNameDependenciesReceivedArguments
+            xcodeProject.createAggregatedTargetInRootProjectNameDependenciesReceivedArguments
         )
         XCTAssertEqual(createAggregatedArguments.name, "RugbyPods")
         XCTAssertEqual(createAggregatedArguments.dependencies.count, 2)

--- a/Tests/FoundationTests/Core/Use/XCFrameworksPatcherTests.swift
+++ b/Tests/FoundationTests/Core/Use/XCFrameworksPatcherTests.swift
@@ -1,0 +1,88 @@
+@testable import RugbyFoundation
+import XCTest
+
+final class XCFrameworksPatcherTests: XCTestCase {
+    private var sut: IXCFrameworksPatcher!
+    private var xcodeProject: IInternalXcodeProjectMock!
+    private var xcodePhaseEditor: IXcodePhaseEditorMock!
+    private var xcodeBuildConfigurationEditor: IXcodeBuildConfigurationEditorMock!
+
+    override func setUp() {
+        super.setUp()
+        xcodeProject = IInternalXcodeProjectMock()
+        xcodePhaseEditor = IXcodePhaseEditorMock()
+        xcodeBuildConfigurationEditor = IXcodeBuildConfigurationEditorMock()
+        sut = XCFrameworksPatcher(
+            xcodeProject: xcodeProject,
+            xcodePhaseEditor: xcodePhaseEditor,
+            xcodeBuildConfigurationEditor: xcodeBuildConfigurationEditor
+        )
+    }
+
+    override func tearDown() {
+        xcodeProject = nil
+        xcodePhaseEditor = nil
+        xcodeBuildConfigurationEditor = nil
+        sut = nil
+        super.tearDown()
+    }
+}
+
+extension XCFrameworksPatcherTests {
+    func test_detachXCFrameworkBuildPhase() async throws {
+        let target0 = IInternalTargetMock()
+        target0.underlyingUuid = "target0_uuid"
+        let target1 = IInternalTargetMock()
+        target1.underlyingName = "target1_name"
+        target1.underlyingUuid = "target1_uuid"
+        let project1 = IProjectMock()
+        target1.underlyingProject = project1
+        let targets = [target0.uuid: target0, target1.uuid: target1]
+        xcodePhaseEditor.filterXCFrameworksPhaseTargetsReturnValue = [target1.uuid: target1]
+        let aggregatedTarget = IInternalTargetMock()
+        aggregatedTarget.underlyingUuid = "aggregatedTarget_uuid"
+        xcodeProject.createAggregatedTargetNameInDependenciesReturnValue = aggregatedTarget
+
+        // Act
+        try await sut.detachXCFrameworkBuildPhase(from: targets)
+
+        // Assert
+        XCTAssertEqual(xcodePhaseEditor.filterXCFrameworksPhaseTargetsCallsCount, 1)
+        XCTAssertEqual(xcodePhaseEditor.filterXCFrameworksPhaseTargetsReceivedTargets?.count, 2)
+
+        XCTAssertEqual(xcodeProject.createAggregatedTargetNameInDependenciesCallsCount, 1)
+        XCTAssertEqual(xcodeProject.createAggregatedTargetNameInDependenciesReceivedArguments?.name,
+                       "target1_name-XCFramework")
+        XCTAssertIdentical(xcodeProject.createAggregatedTargetNameInDependenciesReceivedArguments?.project, project1)
+
+        XCTAssertEqual(xcodePhaseEditor.copyXCFrameworksPhaseFromToCallsCount, 1)
+        XCTAssertIdentical(xcodePhaseEditor.copyXCFrameworksPhaseFromToReceivedArguments?.target, target1)
+        XCTAssertIdentical(xcodePhaseEditor.copyXCFrameworksPhaseFromToReceivedArguments?.destinationTarget,
+                           aggregatedTarget)
+
+        XCTAssertEqual(xcodeBuildConfigurationEditor.copyBuildConfigurationListFromToCallsCount, 1)
+        XCTAssertIdentical(xcodeBuildConfigurationEditor.copyBuildConfigurationListFromToReceivedArguments?.target,
+                           target1)
+        XCTAssertIdentical(
+            xcodeBuildConfigurationEditor.copyBuildConfigurationListFromToReceivedArguments?.destinationTarget,
+            aggregatedTarget
+        )
+
+        XCTAssertEqual(xcodeProject.addDependenciesToCallsCount, 1)
+        XCTAssertEqual(xcodeProject.addDependenciesToReceivedArguments?.dependencies.count, 1)
+        XCTAssertIdentical(xcodeProject.addDependenciesToReceivedArguments?.dependencies.first?.value, aggregatedTarget)
+        XCTAssertIdentical(xcodeProject.addDependenciesToReceivedArguments?.target, target1)
+
+        XCTAssertEqual(xcodeProject.saveCallsCount, 1)
+    }
+
+    func test_detachXCFrameworkBuildPhase_empty() async throws {
+        xcodePhaseEditor.filterXCFrameworksPhaseTargetsReturnValue = [:]
+
+        // Act
+        try await sut.detachXCFrameworkBuildPhase(from: [:])
+
+        // Assert
+        XCTAssertEqual(xcodeProject.saveCallsCount, 0)
+    }
+}

--- a/Tests/FoundationTests/Mocks/IInternalXcodeProjectMock.generated.swift
+++ b/Tests/FoundationTests/Mocks/IInternalXcodeProjectMock.generated.swift
@@ -137,6 +137,28 @@ final class IInternalXcodeProjectMock: IInternalXcodeProject {
         try await deleteTargetsKeepGroupsClosure?(targetsForRemove, keepGroups)
     }
 
+    // MARK: - addDependencies
+
+    var addDependenciesToThrowableError: Error?
+    var addDependenciesToCallsCount = 0
+    var addDependenciesToCalled: Bool { addDependenciesToCallsCount > 0 }
+    var addDependenciesToReceivedArguments: (dependencies: TargetsMap, target: IInternalTarget)?
+    var addDependenciesToReceivedInvocations: [(dependencies: TargetsMap, target: IInternalTarget)] = []
+    private let addDependenciesToReceivedInvocationsLock = NSRecursiveLock()
+    var addDependenciesToClosure: ((TargetsMap, IInternalTarget) throws -> Void)?
+
+    func addDependencies(_ dependencies: TargetsMap, to target: IInternalTarget) throws {
+        addDependenciesToCallsCount += 1
+        addDependenciesToReceivedArguments = (dependencies: dependencies, target: target)
+        addDependenciesToReceivedInvocationsLock.withLock {
+            addDependenciesToReceivedInvocations.append((dependencies: dependencies, target: target))
+        }
+        if let error = addDependenciesToThrowableError {
+            throw error
+        }
+        try addDependenciesToClosure?(dependencies, target)
+    }
+
     // MARK: - createTestingScheme
 
     var createTestingSchemeBuildConfigurationTestplanPathCallsCount = 0

--- a/Tests/FoundationTests/Mocks/IInternalXcodeProjectMock.generated.swift
+++ b/Tests/FoundationTests/Mocks/IInternalXcodeProjectMock.generated.swift
@@ -63,28 +63,55 @@ final class IInternalXcodeProjectMock: IInternalXcodeProject {
 
     // MARK: - createAggregatedTarget
 
-    var createAggregatedTargetNameDependenciesThrowableError: Error?
-    var createAggregatedTargetNameDependenciesCallsCount = 0
-    var createAggregatedTargetNameDependenciesCalled: Bool { createAggregatedTargetNameDependenciesCallsCount > 0 }
-    var createAggregatedTargetNameDependenciesReceivedArguments: (name: String, dependencies: TargetsMap)?
-    var createAggregatedTargetNameDependenciesReceivedInvocations: [(name: String, dependencies: TargetsMap)] = []
-    private let createAggregatedTargetNameDependenciesReceivedInvocationsLock = NSRecursiveLock()
-    var createAggregatedTargetNameDependenciesReturnValue: IInternalTarget!
-    var createAggregatedTargetNameDependenciesClosure: ((String, TargetsMap) async throws -> IInternalTarget)?
+    var createAggregatedTargetNameInDependenciesThrowableError: Error?
+    var createAggregatedTargetNameInDependenciesCallsCount = 0
+    var createAggregatedTargetNameInDependenciesCalled: Bool { createAggregatedTargetNameInDependenciesCallsCount > 0 }
+    var createAggregatedTargetNameInDependenciesReceivedArguments: (name: String, project: IProject, dependencies: TargetsMap)?
+    var createAggregatedTargetNameInDependenciesReceivedInvocations: [(name: String, project: IProject, dependencies: TargetsMap)] = []
+    private let createAggregatedTargetNameInDependenciesReceivedInvocationsLock = NSRecursiveLock()
+    var createAggregatedTargetNameInDependenciesReturnValue: IInternalTarget!
+    var createAggregatedTargetNameInDependenciesClosure: ((String, IProject, TargetsMap) async throws -> IInternalTarget)?
 
-    func createAggregatedTarget(name: String, dependencies: TargetsMap) async throws -> IInternalTarget {
-        createAggregatedTargetNameDependenciesCallsCount += 1
-        createAggregatedTargetNameDependenciesReceivedArguments = (name: name, dependencies: dependencies)
-        createAggregatedTargetNameDependenciesReceivedInvocationsLock.withLock {
-            createAggregatedTargetNameDependenciesReceivedInvocations.append((name: name, dependencies: dependencies))
+    func createAggregatedTarget(name: String, in project: IProject, dependencies: TargetsMap) async throws -> IInternalTarget {
+        createAggregatedTargetNameInDependenciesCallsCount += 1
+        createAggregatedTargetNameInDependenciesReceivedArguments = (name: name, project: project, dependencies: dependencies)
+        createAggregatedTargetNameInDependenciesReceivedInvocationsLock.withLock {
+            createAggregatedTargetNameInDependenciesReceivedInvocations.append((name: name, project: project, dependencies: dependencies))
         }
-        if let error = createAggregatedTargetNameDependenciesThrowableError {
+        if let error = createAggregatedTargetNameInDependenciesThrowableError {
             throw error
         }
-        if let createAggregatedTargetNameDependenciesClosure = createAggregatedTargetNameDependenciesClosure {
-            return try await createAggregatedTargetNameDependenciesClosure(name, dependencies)
+        if let createAggregatedTargetNameInDependenciesClosure = createAggregatedTargetNameInDependenciesClosure {
+            return try await createAggregatedTargetNameInDependenciesClosure(name, project, dependencies)
         } else {
-            return createAggregatedTargetNameDependenciesReturnValue
+            return createAggregatedTargetNameInDependenciesReturnValue
+        }
+    }
+
+    // MARK: - createAggregatedTargetInRootProject
+
+    var createAggregatedTargetInRootProjectNameDependenciesThrowableError: Error?
+    var createAggregatedTargetInRootProjectNameDependenciesCallsCount = 0
+    var createAggregatedTargetInRootProjectNameDependenciesCalled: Bool { createAggregatedTargetInRootProjectNameDependenciesCallsCount > 0 }
+    var createAggregatedTargetInRootProjectNameDependenciesReceivedArguments: (name: String, dependencies: TargetsMap)?
+    var createAggregatedTargetInRootProjectNameDependenciesReceivedInvocations: [(name: String, dependencies: TargetsMap)] = []
+    private let createAggregatedTargetInRootProjectNameDependenciesReceivedInvocationsLock = NSRecursiveLock()
+    var createAggregatedTargetInRootProjectNameDependenciesReturnValue: IInternalTarget!
+    var createAggregatedTargetInRootProjectNameDependenciesClosure: ((String, TargetsMap) async throws -> IInternalTarget)?
+
+    func createAggregatedTargetInRootProject(name: String, dependencies: TargetsMap) async throws -> IInternalTarget {
+        createAggregatedTargetInRootProjectNameDependenciesCallsCount += 1
+        createAggregatedTargetInRootProjectNameDependenciesReceivedArguments = (name: name, dependencies: dependencies)
+        createAggregatedTargetInRootProjectNameDependenciesReceivedInvocationsLock.withLock {
+            createAggregatedTargetInRootProjectNameDependenciesReceivedInvocations.append((name: name, dependencies: dependencies))
+        }
+        if let error = createAggregatedTargetInRootProjectNameDependenciesThrowableError {
+            throw error
+        }
+        if let createAggregatedTargetInRootProjectNameDependenciesClosure = createAggregatedTargetInRootProjectNameDependenciesClosure {
+            return try await createAggregatedTargetInRootProjectNameDependenciesClosure(name, dependencies)
+        } else {
+            return createAggregatedTargetInRootProjectNameDependenciesReturnValue
         }
     }
 

--- a/Tests/FoundationTests/Mocks/IXCFrameworksPatcherMock.generated.swift
+++ b/Tests/FoundationTests/Mocks/IXCFrameworksPatcherMock.generated.swift
@@ -1,0 +1,34 @@
+// Generated using Sourcery 2.1.1 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+// swiftlint:disable all
+
+import Foundation
+@testable import RugbyFoundation
+
+final class IXCFrameworksPatcherMock: IXCFrameworksPatcher {
+
+    // MARK: - detachXCFrameworkBuildPhase
+
+    var detachXCFrameworkBuildPhaseFromThrowableError: Error?
+    var detachXCFrameworkBuildPhaseFromCallsCount = 0
+    var detachXCFrameworkBuildPhaseFromCalled: Bool { detachXCFrameworkBuildPhaseFromCallsCount > 0 }
+    var detachXCFrameworkBuildPhaseFromReceivedTargets: TargetsMap?
+    var detachXCFrameworkBuildPhaseFromReceivedInvocations: [TargetsMap] = []
+    private let detachXCFrameworkBuildPhaseFromReceivedInvocationsLock = NSRecursiveLock()
+    var detachXCFrameworkBuildPhaseFromClosure: ((TargetsMap) async throws -> Void)?
+
+    func detachXCFrameworkBuildPhase(from targets: TargetsMap) async throws {
+        detachXCFrameworkBuildPhaseFromCallsCount += 1
+        detachXCFrameworkBuildPhaseFromReceivedTargets = targets
+        detachXCFrameworkBuildPhaseFromReceivedInvocationsLock.withLock {
+            detachXCFrameworkBuildPhaseFromReceivedInvocations.append(targets)
+        }
+        if let error = detachXCFrameworkBuildPhaseFromThrowableError {
+            throw error
+        }
+        try await detachXCFrameworkBuildPhaseFromClosure?(targets)
+    }
+}
+
+// swiftlint:enable all

--- a/Tests/FoundationTests/Mocks/IXcodeBuildConfigurationEditorMock.generated.swift
+++ b/Tests/FoundationTests/Mocks/IXcodeBuildConfigurationEditorMock.generated.swift
@@ -1,0 +1,30 @@
+// Generated using Sourcery 2.1.1 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+// swiftlint:disable all
+
+import Foundation
+@testable import RugbyFoundation
+
+final class IXcodeBuildConfigurationEditorMock: IXcodeBuildConfigurationEditor {
+
+    // MARK: - copyBuildConfigurationList
+
+    var copyBuildConfigurationListFromToCallsCount = 0
+    var copyBuildConfigurationListFromToCalled: Bool { copyBuildConfigurationListFromToCallsCount > 0 }
+    var copyBuildConfigurationListFromToReceivedArguments: (target: IInternalTarget, destinationTarget: IInternalTarget)?
+    var copyBuildConfigurationListFromToReceivedInvocations: [(target: IInternalTarget, destinationTarget: IInternalTarget)] = []
+    private let copyBuildConfigurationListFromToReceivedInvocationsLock = NSRecursiveLock()
+    var copyBuildConfigurationListFromToClosure: ((IInternalTarget, IInternalTarget) -> Void)?
+
+    func copyBuildConfigurationList(from target: IInternalTarget, to destinationTarget: IInternalTarget) {
+        copyBuildConfigurationListFromToCallsCount += 1
+        copyBuildConfigurationListFromToReceivedArguments = (target: target, destinationTarget: destinationTarget)
+        copyBuildConfigurationListFromToReceivedInvocationsLock.withLock {
+            copyBuildConfigurationListFromToReceivedInvocations.append((target: target, destinationTarget: destinationTarget))
+        }
+        copyBuildConfigurationListFromToClosure?(target, destinationTarget)
+    }
+}
+
+// swiftlint:enable all

--- a/Tests/FoundationTests/Mocks/IXcodePhaseEditorMock.generated.swift
+++ b/Tests/FoundationTests/Mocks/IXcodePhaseEditorMock.generated.swift
@@ -14,12 +14,15 @@ final class IXcodePhaseEditorMock: IXcodePhaseEditor {
     var keepOnlyPreSourceScriptPhasesInCalled: Bool { keepOnlyPreSourceScriptPhasesInCallsCount > 0 }
     var keepOnlyPreSourceScriptPhasesInReceivedTargets: TargetsMap?
     var keepOnlyPreSourceScriptPhasesInReceivedInvocations: [TargetsMap] = []
+    private let keepOnlyPreSourceScriptPhasesInReceivedInvocationsLock = NSRecursiveLock()
     var keepOnlyPreSourceScriptPhasesInClosure: ((TargetsMap) async -> Void)?
 
     func keepOnlyPreSourceScriptPhases(in targets: TargetsMap) async {
         keepOnlyPreSourceScriptPhasesInCallsCount += 1
         keepOnlyPreSourceScriptPhasesInReceivedTargets = targets
-        keepOnlyPreSourceScriptPhasesInReceivedInvocations.append(targets)
+        keepOnlyPreSourceScriptPhasesInReceivedInvocationsLock.withLock {
+            keepOnlyPreSourceScriptPhasesInReceivedInvocations.append(targets)
+        }
         await keepOnlyPreSourceScriptPhasesInClosure?(targets)
     }
 
@@ -29,13 +32,57 @@ final class IXcodePhaseEditorMock: IXcodePhaseEditor {
     var deleteCopyXCFrameworksPhaseInCalled: Bool { deleteCopyXCFrameworksPhaseInCallsCount > 0 }
     var deleteCopyXCFrameworksPhaseInReceivedTargets: TargetsMap?
     var deleteCopyXCFrameworksPhaseInReceivedInvocations: [TargetsMap] = []
+    private let deleteCopyXCFrameworksPhaseInReceivedInvocationsLock = NSRecursiveLock()
     var deleteCopyXCFrameworksPhaseInClosure: ((TargetsMap) async -> Void)?
 
     func deleteCopyXCFrameworksPhase(in targets: TargetsMap) async {
         deleteCopyXCFrameworksPhaseInCallsCount += 1
         deleteCopyXCFrameworksPhaseInReceivedTargets = targets
-        deleteCopyXCFrameworksPhaseInReceivedInvocations.append(targets)
+        deleteCopyXCFrameworksPhaseInReceivedInvocationsLock.withLock {
+            deleteCopyXCFrameworksPhaseInReceivedInvocations.append(targets)
+        }
         await deleteCopyXCFrameworksPhaseInClosure?(targets)
+    }
+
+    // MARK: - copyXCFrameworksPhase
+
+    var copyXCFrameworksPhaseFromToCallsCount = 0
+    var copyXCFrameworksPhaseFromToCalled: Bool { copyXCFrameworksPhaseFromToCallsCount > 0 }
+    var copyXCFrameworksPhaseFromToReceivedArguments: (target: IInternalTarget, destinationTarget: IInternalTarget)?
+    var copyXCFrameworksPhaseFromToReceivedInvocations: [(target: IInternalTarget, destinationTarget: IInternalTarget)] = []
+    private let copyXCFrameworksPhaseFromToReceivedInvocationsLock = NSRecursiveLock()
+    var copyXCFrameworksPhaseFromToClosure: ((IInternalTarget, IInternalTarget) -> Void)?
+
+    func copyXCFrameworksPhase(from target: IInternalTarget, to destinationTarget: IInternalTarget) {
+        copyXCFrameworksPhaseFromToCallsCount += 1
+        copyXCFrameworksPhaseFromToReceivedArguments = (target: target, destinationTarget: destinationTarget)
+        copyXCFrameworksPhaseFromToReceivedInvocationsLock.withLock {
+            copyXCFrameworksPhaseFromToReceivedInvocations.append((target: target, destinationTarget: destinationTarget))
+        }
+        copyXCFrameworksPhaseFromToClosure?(target, destinationTarget)
+    }
+
+    // MARK: - filterXCFrameworksPhaseTargets
+
+    var filterXCFrameworksPhaseTargetsCallsCount = 0
+    var filterXCFrameworksPhaseTargetsCalled: Bool { filterXCFrameworksPhaseTargetsCallsCount > 0 }
+    var filterXCFrameworksPhaseTargetsReceivedTargets: TargetsMap?
+    var filterXCFrameworksPhaseTargetsReceivedInvocations: [TargetsMap] = []
+    private let filterXCFrameworksPhaseTargetsReceivedInvocationsLock = NSRecursiveLock()
+    var filterXCFrameworksPhaseTargetsReturnValue: TargetsMap!
+    var filterXCFrameworksPhaseTargetsClosure: ((TargetsMap) -> TargetsMap)?
+
+    func filterXCFrameworksPhaseTargets(_ targets: TargetsMap) -> TargetsMap {
+        filterXCFrameworksPhaseTargetsCallsCount += 1
+        filterXCFrameworksPhaseTargetsReceivedTargets = targets
+        filterXCFrameworksPhaseTargetsReceivedInvocationsLock.withLock {
+            filterXCFrameworksPhaseTargetsReceivedInvocations.append(targets)
+        }
+        if let filterXCFrameworksPhaseTargetsClosure = filterXCFrameworksPhaseTargetsClosure {
+            return filterXCFrameworksPhaseTargetsClosure(targets)
+        } else {
+            return filterXCFrameworksPhaseTargetsReturnValue
+        }
     }
 }
 

--- a/Tests/FoundationTests/Mocks/Mocks.swift
+++ b/Tests/FoundationTests/Mocks/Mocks.swift
@@ -164,4 +164,7 @@ extension ITargetsPrinter {}
 extension IXcodePhaseEditor {}
 
 // sourcery: AutoMockable, testableImports = ["RugbyFoundation"]
+extension IXCFrameworksPatcher {}
+
+// sourcery: AutoMockable, testableImports = ["RugbyFoundation"]
 extension IXcodeBuildConfigurationEditor {}

--- a/Tests/FoundationTests/Mocks/Mocks.swift
+++ b/Tests/FoundationTests/Mocks/Mocks.swift
@@ -162,3 +162,6 @@ extension ITargetsPrinter {}
 
 // sourcery: AutoMockable, testableImports = ["RugbyFoundation"]
 extension IXcodePhaseEditor {}
+
+// sourcery: AutoMockable, testableImports = ["RugbyFoundation"]
+extension IXcodeBuildConfigurationEditor {}

--- a/Tests/FoundationTests/Mocks/Mocks.swift
+++ b/Tests/FoundationTests/Mocks/Mocks.swift
@@ -160,4 +160,5 @@ extension ISimCTL {}
 // sourcery: AutoMockable, testableImports = ["RugbyFoundation"]
 extension ITargetsPrinter {}
 
-// TODO: Needs to improve Sourcery template to generate mocks automatically w/o manual editing
+// sourcery: AutoMockable, testableImports = ["RugbyFoundation"]
+extension IXcodePhaseEditor {}

--- a/Tests/FoundationTests/XcodeProject/Services/XcodeBuildConfigurationEditorTests.swift
+++ b/Tests/FoundationTests/XcodeProject/Services/XcodeBuildConfigurationEditorTests.swift
@@ -1,0 +1,95 @@
+@testable import RugbyFoundation
+import XcodeProj
+import XCTest
+
+final class XcodeBuildConfigurationEditorTests: XCTestCase {
+    private var sut: IXcodeBuildConfigurationEditor!
+
+    override func setUp() {
+        super.setUp()
+        sut = XcodeBuildConfigurationEditor()
+    }
+
+    override func tearDown() {
+        sut = nil
+        super.tearDown()
+    }
+}
+
+extension XcodeBuildConfigurationEditorTests {
+    func test_copyBuildConfigurationList() {
+        let target0 = IInternalTargetMock()
+        target0.underlyingName = "ProcessOut"
+        target0.underlyingUuid = "3386D53BC7DA45071FC1EA7213FCFC11"
+        let pbxTarget0 = PBXTarget(name: "ProcessOut")
+        let baseConfiguration0 = PBXFileReference(
+            sourceTree: .group,
+            path: "ProcessOut.debug.xcconfig",
+            includeInIndex: true
+        )
+        let configuration0 = XCBuildConfiguration(
+            name: "Debug",
+            baseConfiguration: baseConfiguration0,
+            buildSettings: ["SDKROOT": "iphoneos", "DEFINES_MODULE": "YES", "PRODUCT_MODULE_NAME": "ProcessOut"]
+        )
+        let baseConfiguration1 = PBXFileReference(
+            sourceTree: .group,
+            path: "ProcessOut.release.xcconfig",
+            includeInIndex: true
+        )
+        let configuration1 = XCBuildConfiguration(
+            name: "Release",
+            baseConfiguration: baseConfiguration1,
+            buildSettings: ["SDKROOT": "iphoneos", "DEFINES_MODULE": "YES", "PRODUCT_MODULE_NAME": "ProcessOut"]
+        )
+        let buildConfigurationList0 = XCConfigurationList(
+            buildConfigurations: [configuration0, configuration1],
+            defaultConfigurationName: "Debug",
+            defaultConfigurationIsVisible: false
+        )
+        pbxTarget0.buildConfigurationList = buildConfigurationList0
+        target0.underlyingPbxTarget = pbxTarget0
+        let target1 = IInternalTargetMock()
+        target1.underlyingName = "ProcessOut-XCFramework"
+        target1.underlyingUuid = "target1_uuid"
+        let project1 = IProjectMock()
+        project1.pbxProj = PBXProj()
+        target1.project = project1
+        let pbxTarget1 = PBXTarget(name: "ProcessOut-XCFramework")
+        target1.underlyingPbxTarget = pbxTarget1
+
+        // Act
+        sut.copyBuildConfigurationList(from: target0, to: target1)
+
+        // Assert
+        XCTAssertEqual(target1.project.pbxProj.buildConfigurations.count, 2)
+        let expectedConfiguration0 = XCBuildConfiguration(
+            name: "Debug",
+            baseConfiguration: baseConfiguration0,
+            buildSettings: ["SDKROOT": "iphoneos", "DEFINES_MODULE": "YES", "PRODUCT_MODULE_NAME": "ProcessOut"]
+        )
+        let expectedConfiguration1 = XCBuildConfiguration(
+            name: "Release",
+            baseConfiguration: baseConfiguration1,
+            buildSettings: ["SDKROOT": "iphoneos", "DEFINES_MODULE": "YES", "PRODUCT_MODULE_NAME": "ProcessOut"]
+        )
+        XCTAssertEqual(target1.project.pbxProj.buildConfigurations.sorted(by: { $0.name < $1.name }),
+                       [expectedConfiguration0, expectedConfiguration1])
+
+        XCTAssertEqual(target1.project.pbxProj.configurationLists.count, 1)
+        XCTAssertEqual(
+            target1.project.pbxProj.configurationLists[0].buildConfigurations.sorted(by: { $0.name < $1.name }),
+            [expectedConfiguration0, expectedConfiguration1]
+        )
+        XCTAssertEqual(target1.project.pbxProj.configurationLists[0].defaultConfigurationName, "Debug")
+        XCTAssertEqual(target1.project.pbxProj.configurationLists[0].defaultConfigurationIsVisible, false)
+
+        XCTAssertEqual(target1.pbxTarget.buildConfigurationList?.defaultConfigurationName, "Debug")
+        XCTAssertEqual(target1.pbxTarget.buildConfigurationList?.defaultConfigurationIsVisible, false)
+        XCTAssertEqual(target1.pbxTarget.buildConfigurationList?.buildConfigurations.count, 2)
+        XCTAssertEqual(
+            target1.pbxTarget.buildConfigurationList?.buildConfigurations.sorted(by: { $0.name < $1.name }),
+            [expectedConfiguration0, expectedConfiguration1]
+        )
+    }
+}

--- a/Tests/FoundationTests/XcodeProject/Services/XcodePhaseEditorTests.swift
+++ b/Tests/FoundationTests/XcodeProject/Services/XcodePhaseEditorTests.swift
@@ -106,4 +106,66 @@ extension XcodePhaseEditorTests {
         expectedAggregateTargetBuildPhases.remove(at: 1)
         XCTAssertEqual(resultAggregateTargetBuildPhases, expectedAggregateTargetBuildPhases)
     }
+
+    func test_filterXCFrameworksPhaseTargets() {
+        let target0 = IInternalTargetMock()
+        target0.underlyingName = "target0_name"
+        target0.underlyingUuid = "target0_uuid"
+        target0.buildPhases = [BuildPhase(name: "Some Script", type: .runScript)]
+        let target1 = IInternalTargetMock()
+        target1.underlyingName = "target1_name"
+        target1.underlyingUuid = "target1_uuid"
+        target1.buildPhases = [BuildPhase(name: "[CP] Copy XCFrameworks", type: .runScript)]
+        let target2 = IInternalTargetMock()
+        target2.underlyingName = "target2_name"
+        target2.underlyingUuid = "target2_uuid"
+        target2.buildPhases = [BuildPhase(name: "Sources", type: .sources)]
+
+        // Act
+        let filteredTargets = sut.filterXCFrameworksPhaseTargets([
+            target0.uuid: target0,
+            target1.uuid: target1,
+            target2.uuid: target2
+        ])
+
+        // Assert
+        XCTAssertEqual(filteredTargets.count, 1)
+        XCTAssertEqual(filteredTargets.first?.value.name, target1.name)
+    }
+
+    func test_copyXCFrameworksPhase() {
+        let target0 = IInternalTargetMock()
+        target0.underlyingName = "target0_name"
+        target0.underlyingUuid = "target0_uuid"
+        target0.underlyingPbxTarget = PBXTarget(name: "target0_name")
+        let project = IProjectMock()
+        project.pbxProj = PBXProj()
+        target0.underlyingProject = project
+        let target1 = IInternalTargetMock()
+        target1.underlyingName = "target1_name"
+        target1.underlyingUuid = "target1_uuid"
+        target1.underlyingPbxTarget = PBXTarget(name: "target1_name")
+        let xcframeworkBuildPhase = PBXShellScriptBuildPhase(
+            files: [],
+            name: "[CP] Copy XCFrameworks",
+            inputPaths: ["inputPaths_test"],
+            outputPaths: ["outputPaths_test"],
+            inputFileListPaths: ["inputFileListPaths_test"],
+            outputFileListPaths: ["outputFileListPaths_test"],
+            shellPath: "shellPath_test",
+            shellScript: "shellScript_test",
+            buildActionMask: 99,
+            runOnlyForDeploymentPostprocessing: false,
+            showEnvVarsInLog: false,
+            alwaysOutOfDate: false,
+            dependencyFile: "dependencyFile_test"
+        )
+        target1.pbxTarget.buildPhases = [xcframeworkBuildPhase]
+
+        // Act
+        sut.copyXCFrameworksPhase(from: target1, to: target0)
+
+        // Assert
+        XCTAssertEqual(target0.pbxTarget.buildPhases.first, xcframeworkBuildPhase)
+    }
 }


### PR DESCRIPTION
### Description
<!--Please describe your pull request.-->
> The problem occurs when using the "XCFramework" script phase in combination with the "sources" phase.
We need to separate the "XCFramework" script phase from the built target to create a separate aggregate target.

These changes allow us to use podspec files with:
```ruby
s.vendored_frameworks = "Some.xcframework"
s.source_files        = 'Sources/SomePod/**/*.swift'
```

### References
<!--Provide links to an existing issue or external references/discussions, if appropriate.-->
- #382 

### Checklist (I have ...)
- [x] 🧐 Followed the code style of the rest of the project
- [ ] 📖 Updated the documentation, if necessary
- [x] 👨🏻‍🔧 Added at least one test which validates that my change is working, if appropriate
- [x] 👮🏻‍♂️ Run `make lint` and fixed all warnings
- [x] ✅ Run `make test` and fixed all tests

❤️ Thanks for contributing to the 🏈 Rugby!
