### PR TITLE
🚀 Improve 4XX error message management

### DIFF
--- a/Sources/Rugby/Core/Dependencies/Update/GitHubReleaseListLoader.swift
+++ b/Sources/Rugby/Core/Dependencies/Update/GitHubReleaseListLoader.swift
@@ -13,17 +13,17 @@ struct Release {
 // MARK: - Implementation
 
 final class GitHubReleaseListLoader {
-
     enum Error: LocalizedError {
         case couldNotRetrieveVersions(String)
 
         var errorDescription: String? {
             switch self {
-            case .couldNotRetrieveVersions(let apiMessage):
+            case let .couldNotRetrieveVersions(apiMessage):
                 return apiMessage
             }
         }
     }
+
     private let paths: GitHubUpdaterPaths
 
     init(paths: GitHubUpdaterPaths) {
@@ -50,13 +50,13 @@ final class GitHubReleaseListLoader {
             fatalError("Couldn't build url.")
         }
         let (data, response) = try await URLSession.shared.data(from: url)
-        if let httpResponse = response as? HTTPURLResponse, (400..<500) ~= httpResponse.statusCode {
+        if let httpResponse = response as? HTTPURLResponse, (400 ..< 500) ~= httpResponse.statusCode {
             let errorModel = try parseError(data)
             throw Error.couldNotRetrieveVersions(errorModel.message)
         }
         return data
     }
-    
+
     private func parseError(_ data: Data) throws -> ReleaseResponseErrorModel {
         let decoder = JSONDecoder()
         let model = try decoder.decode(ReleaseResponseErrorModel.self, from: data)
@@ -96,7 +96,7 @@ private struct ReleaseResponseModel: Decodable {
 }
 
 private struct ReleaseResponseErrorModel: Decodable {
-  let message: String
+    let message: String
 }
 
 // swiftlint:enable identifier_name


### PR DESCRIPTION
### Description
This PR improves messaging for errors in the 4XX range when updating Rugby version directly from Github.
It is related to the issue I report in this discussion: https://github.com/swiftyfinch/Rugby/discussions/386

Before these changes, the output looked like:
```
⚑ Update
  ◑ [0s] Loading Releases
⛔️ Error: typeMismatch(Swift.Array<Any>, Swift.DecodingError.Context(codingPath: [], debugDescription: "Expected to decode Array<Any> but found a dictionary instead.", underlyingError: nil))
```

With these changes, the output looks like:
```
rugby update
⚑ Update
  ⚑ Loading Releases
⛔️ Error: API rate limit exceeded for XXX.XXX.XXX.XXX. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)
```

### References
https://github.com/swiftyfinch/Rugby/discussions/386

### Checklist (I have ...)
- [x] 🧐 Followed the code style of the rest of the project
- [x] 📖 Updated the documentation, if necessary (N/A)
- [ ] 👨🏻‍🔧 Added at least one test which validates that my change is working, if appropriate
- [x] 👮🏻‍♂️ Run `make lint` and fixed all warnings
- [x] ✅ Run `make test` and fixed all tests

❤️ Thanks for contributing to the 🏈 Rugby!
