### PR TITLE
Sevenzip support

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -37,6 +37,15 @@
       }
     },
     {
+      "identity" : "plzmasdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/OlehKulykov/PLzmaSDK",
+      "state" : {
+        "revision" : "9f48b99d8aee09c98184e4610b40ee87487d1643",
+        "version" : "1.4.2"
+      }
+    },
+    {
       "identity" : "rainbow",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/onevcat/Rainbow",

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,8 @@ let package = Package(
         .package(url: "https://github.com/tuist/xcbeautify", from: "1.6.0"),
         .package(url: "https://github.com/jpsim/Yams", from: "5.0.6"),
         .package(url: "https://github.com/weichsel/ZIPFoundation", from: "0.9.18"),
-        .package(url: "https://github.com/swiftyfinch/Fish", from: "0.1.2")
+        .package(url: "https://github.com/swiftyfinch/Fish", from: "0.1.2"),
+        .package(url: "https://github.com/OlehKulykov/PLzmaSDK", from: "1.4.2")
     ],
     targets: [
         // rugby
@@ -38,7 +39,8 @@ let package = Package(
             .product(name: "XcbeautifyLib", package: "xcbeautify"),
             "Yams",
             "ZIPFoundation",
-            "Fish"
+            "Fish",
+            "PLzmaSDK"
         ]),
         .testTarget(name: "FoundationTests", dependencies: ["RugbyFoundation"])
     ]

--- a/Sources/Rugby/Commands/Basic/Warmup.swift
+++ b/Sources/Rugby/Commands/Basic/Warmup.swift
@@ -69,11 +69,13 @@ extension Warmup: RunnableCommand {
         }
         try await dependencies.warmupManager(
             timeoutIntervalForRequest: TimeInterval(timeout),
-            httpMaximumConnectionsPerHost: maxConnections
+            httpMaximumConnectionsPerHost: maxConnections,
+            archiveType: commonOptions.archiveType
         ).warmup(
             mode: mode,
             targetsOptions: buildOptions.targetsOptions.foundation(),
             options: buildOptions.xcodeBuildOptions(),
+            archiveType: commonOptions.archiveType,
             maxInParallel: maxConnections,
             headers: headers.parseHeaders()
         )

--- a/Sources/Rugby/Commands/Common/CommonOptions.swift
+++ b/Sources/Rugby/Commands/Common/CommonOptions.swift
@@ -11,6 +11,9 @@ struct CommonOptions: ParsableCommand {
 
     @Flag(name: .shortAndLong, help: "Decrease verbosity level.")
     var quiet: Int
+
+    @Option(name: .long, help: "Archive type: zip, 7z")
+    var archiveType: RugbyFoundation.ArchiveType = .zip
 }
 
 enum OutputType: String, ExpressibleByArgument {
@@ -34,6 +37,8 @@ enum OutputType: String, ExpressibleByArgument {
         }
     }
 }
+
+extension ArchiveType: ExpressibleByArgument {}
 
 extension CommonOptions {
     var logLevel: LogLevel {

--- a/Sources/RugbyFoundation/Core/Common/ArchiveType.swift
+++ b/Sources/RugbyFoundation/Core/Common/ArchiveType.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+public enum ArchiveType: String {
+    case zip
+    case sevenZip = "7z"
+}

--- a/Sources/RugbyFoundation/Core/Common/ArchiveType.swift
+++ b/Sources/RugbyFoundation/Core/Common/ArchiveType.swift
@@ -1,6 +1,15 @@
 import Foundation
 
-public enum ArchiveType: String {
+public enum ArchiveType: String, CustomStringConvertible {
     case zip
     case sevenZip = "7z"
+    
+    public var description: String {
+        switch self {
+        case .zip:
+            return "zip"
+        case .sevenZip:
+            return "7z"
+        }
+    }
 }

--- a/Sources/RugbyFoundation/Core/Warmup/Decompressor.swift
+++ b/Sources/RugbyFoundation/Core/Warmup/Decompressor.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PLzmaSDK
 import ZIPFoundation
 
 // MARK: - Interface
@@ -9,12 +10,23 @@ protocol IDecompressor: AnyObject {
 
 // MARK: - Implementation
 
-final class Decompressor {
+final class ZipDecompressor {
     private let fileManager = FileManager.default
 }
 
-extension Decompressor: IDecompressor {
+extension ZipDecompressor: IDecompressor {
     func unzipFile(_ zipFilePath: URL, destination: URL) throws {
         try fileManager.unzipItem(at: zipFilePath, to: destination)
+    }
+}
+
+final class SevenZipDecompressor {}
+
+extension SevenZipDecompressor: IDecompressor {
+    func unzipFile(_ zipFilePath: URL, destination: URL) throws {
+        let decoder = try Decoder(stream: InStream(path: Path(zipFilePath.path())), fileType: .sevenZ)
+        _ = try decoder.open()
+
+        _ = try decoder.extract(to: Path(destination.path()))
     }
 }

--- a/Sources/RugbyFoundation/Vault/Commands/Vault+Warmup.swift
+++ b/Sources/RugbyFoundation/Vault/Commands/Vault+Warmup.swift
@@ -7,17 +7,25 @@ public extension Vault {
     ///   - timeoutIntervalForRequest: The timeout interval to use when waiting for additional data.
     ///   - httpMaximumConnectionsPerHost: The maximum number of simultaneous connections to make to a given host.
     func warmupManager(timeoutIntervalForRequest: TimeInterval,
-                       httpMaximumConnectionsPerHost: Int) -> IWarmupManager {
+                       httpMaximumConnectionsPerHost: Int, archiveType: ArchiveType) -> IWarmupManager {
         let xcodeProject = xcode.project(projectPath: router.podsProjectPath)
         let buildTargetsManager = BuildTargetsManager(xcodeProject: xcodeProject)
         let urlSessionConfiguration: URLSessionConfiguration = .default
         urlSessionConfiguration.timeoutIntervalForRequest = timeoutIntervalForRequest
         urlSessionConfiguration.httpMaximumConnectionsPerHost = httpMaximumConnectionsPerHost
+
+        let decompressor: IDecompressor
+        switch archiveType {
+        case .zip:
+            decompressor = ZipDecompressor()
+        case .sevenZip:
+            decompressor = SevenZipDecompressor()
+        }
         let cacheDownloader = CacheDownloader(
             logger: logger,
             reachabilityChecker: ReachabilityChecker(urlSession: URLSession.shared),
             urlSession: URLSession(configuration: urlSessionConfiguration),
-            decompressor: Decompressor()
+            decompressor: decompressor
         )
         return WarmupManager(logger: logger,
                              rugbyXcodeProject: RugbyXcodeProject(xcodeProject: xcodeProject),

--- a/Tests/FoundationTests/Core/Warmup/WarmupManagerTests.swift
+++ b/Tests/FoundationTests/Core/Warmup/WarmupManagerTests.swift
@@ -316,13 +316,13 @@ extension WarmupManagerTests {
 
 extension WarmupManagerTests {
     func test_analyseEndpointZip() async throws {
-        try await self.analyse_endpoint(archiveType: .zip)
+        try await analyse_endpoint(archiveType: .zip)
     }
-    
+
     func test_analyseEndpoint7z() async throws {
-        try await self.analyse_endpoint(archiveType: .sevenZip)
+        try await analyse_endpoint(archiveType: .sevenZip)
     }
-    
+
     func analyse_endpoint(archiveType: ArchiveType) async throws {
         let targetsRegex = try NSRegularExpression(pattern: "^Alamofire|SnapKit$")
         let exceptTargetsRegex = try NSRegularExpression(pattern: "^Moya$")
@@ -367,9 +367,9 @@ extension WarmupManagerTests {
         }
         cacheDownloader.checkIfBinaryIsReachableUrlHeadersClosure = { url, _ in
             switch url.absoluteString {
-            case "https://s3.eu-west-2.amazonaws.com/SnapKit/Debug-iphonesimulator-arm64/eb56c2f.\(archiveType.rawValue)":
+            case "https://s3.eu-west-2.amazonaws.com/SnapKit/Debug-iphonesimulator-arm64/eb56c2f.\(archiveType)":
                 return true
-            case "https://s3.eu-west-2.amazonaws.com/Alamofire/Debug-iphonesimulator-arm64/dbe4415.\(archiveType.rawValue)":
+            case "https://s3.eu-west-2.amazonaws.com/Alamofire/Debug-iphonesimulator-arm64/dbe4415.\(archiveType)":
                 return false
             default: fatalError()
             }
@@ -451,11 +451,11 @@ extension WarmupManagerTests {
         let sortedReachableInvocations = reachableInvocations.sorted { $0.url.absoluteString < $1.url.absoluteString }
         XCTAssertEqual(
             sortedReachableInvocations[0].url.absoluteString,
-            "https://s3.eu-west-2.amazonaws.com/Alamofire/Debug-iphonesimulator-arm64/dbe4415.\(archiveType.rawValue)"
+            "https://s3.eu-west-2.amazonaws.com/Alamofire/Debug-iphonesimulator-arm64/dbe4415.\(archiveType)"
         )
         XCTAssertEqual(
             sortedReachableInvocations[1].url.absoluteString,
-            "https://s3.eu-west-2.amazonaws.com/SnapKit/Debug-iphonesimulator-arm64/eb56c2f.\(archiveType.rawValue)"
+            "https://s3.eu-west-2.amazonaws.com/SnapKit/Debug-iphonesimulator-arm64/eb56c2f.\(archiveType)"
         )
         XCTAssertEqual(loggerBlockInvocations[3].header, "Checking binaries reachability")
         XCTAssertNil(loggerBlockInvocations[3].footer)
@@ -467,7 +467,7 @@ extension WarmupManagerTests {
             logger.logLevelOutputReceivedInvocations[2].text,
             """
             Unreachable:
-            https://s3.eu-west-2.amazonaws.com/Alamofire/Debug-iphonesimulator-arm64/dbe4415.\(archiveType.rawValue)
+            https://s3.eu-west-2.amazonaws.com/Alamofire/Debug-iphonesimulator-arm64/dbe4415.\(archiveType)
             """
         )
         XCTAssertEqual(logger.logLevelOutputReceivedInvocations[2].level, .compact)
@@ -486,15 +486,14 @@ extension WarmupManagerTests {
 // MARK: - General
 
 extension WarmupManagerTests {
-    
     func test_common_test_zip() async throws {
-        try await self.common_test(archiveType: .zip)
+        try await common_test(archiveType: .zip)
     }
-    
+
     func test_common_test_7z() async throws {
-        try await self.common_test(archiveType: .sevenZip)
+        try await common_test(archiveType: .sevenZip)
     }
-    
+
     func common_test(archiveType: ArchiveType) async throws {
         let targetsRegex = try NSRegularExpression(pattern: "^Alamofire|SnapKit$")
         let exceptTargetsRegex = try NSRegularExpression(pattern: "^Moya$")
@@ -546,20 +545,20 @@ extension WarmupManagerTests {
         }
         cacheDownloader.checkIfBinaryIsReachableUrlHeadersClosure = { url, _ in
             switch url.absoluteString {
-            case "https://s3.eu-west-2.amazonaws.com/SnapKit/Debug-iphonesimulator-arm64/eb56c2f.\(archiveType.rawValue)":
+            case "https://s3.eu-west-2.amazonaws.com/SnapKit/Debug-iphonesimulator-arm64/eb56c2f.\(archiveType)":
                 return true
-            case "https://s3.eu-west-2.amazonaws.com/Alamofire/Debug-iphonesimulator-arm64/dbe4415.\(archiveType.rawValue)":
+            case "https://s3.eu-west-2.amazonaws.com/Alamofire/Debug-iphonesimulator-arm64/dbe4415.\(archiveType)":
                 return false
-            case "https://s3.eu-west-2.amazonaws.com/LocalPod/Debug-iphonesimulator-arm64/b3035c7.\(archiveType.rawValue)":
+            case "https://s3.eu-west-2.amazonaws.com/LocalPod/Debug-iphonesimulator-arm64/b3035c7.\(archiveType)":
                 return true
             default: fatalError()
             }
         }
         cacheDownloader.downloadBinaryUrlHeadersToClosure = { url, _, _ in
             switch url.absoluteString {
-            case "https://s3.eu-west-2.amazonaws.com/LocalPod/Debug-iphonesimulator-arm64/b3035c7.\(archiveType.rawValue)":
+            case "https://s3.eu-west-2.amazonaws.com/LocalPod/Debug-iphonesimulator-arm64/b3035c7.\(archiveType)":
                 return true
-            case "https://s3.eu-west-2.amazonaws.com/SnapKit/Debug-iphonesimulator-arm64/eb56c2f.\(archiveType.rawValue)":
+            case "https://s3.eu-west-2.amazonaws.com/SnapKit/Debug-iphonesimulator-arm64/eb56c2f.\(archiveType)":
                 return false
             default: fatalError()
             }
@@ -644,17 +643,17 @@ extension WarmupManagerTests {
         let sortedReachableInvocations = reachableInvocations.sorted { $0.url.absoluteString < $1.url.absoluteString }
         XCTAssertEqual(
             sortedReachableInvocations[0].url.absoluteString,
-            "https://s3.eu-west-2.amazonaws.com/Alamofire/Debug-iphonesimulator-arm64/dbe4415.\(archiveType.rawValue)"
+            "https://s3.eu-west-2.amazonaws.com/Alamofire/Debug-iphonesimulator-arm64/dbe4415.\(archiveType)"
         )
         XCTAssertEqual(sortedReachableInvocations[0].headers, ["test_field": "test_value"])
         XCTAssertEqual(
             sortedReachableInvocations[1].url.absoluteString,
-            "https://s3.eu-west-2.amazonaws.com/LocalPod/Debug-iphonesimulator-arm64/b3035c7.\(archiveType.rawValue)"
+            "https://s3.eu-west-2.amazonaws.com/LocalPod/Debug-iphonesimulator-arm64/b3035c7.\(archiveType)"
         )
         XCTAssertEqual(sortedReachableInvocations[1].headers, ["test_field": "test_value"])
         XCTAssertEqual(
             sortedReachableInvocations[2].url.absoluteString,
-            "https://s3.eu-west-2.amazonaws.com/SnapKit/Debug-iphonesimulator-arm64/eb56c2f.\(archiveType.rawValue)"
+            "https://s3.eu-west-2.amazonaws.com/SnapKit/Debug-iphonesimulator-arm64/eb56c2f.\(archiveType)"
         )
         XCTAssertEqual(sortedReachableInvocations[2].headers, ["test_field": "test_value"])
         XCTAssertEqual(loggerBlockInvocations[3].header, "Checking binaries reachability")
@@ -667,7 +666,7 @@ extension WarmupManagerTests {
             logger.logLevelOutputReceivedInvocations[2].text,
             """
             Unreachable:
-            https://s3.eu-west-2.amazonaws.com/Alamofire/Debug-iphonesimulator-arm64/dbe4415.\(archiveType.rawValue)
+            https://s3.eu-west-2.amazonaws.com/Alamofire/Debug-iphonesimulator-arm64/dbe4415.\(archiveType)
             """
         )
         XCTAssertEqual(logger.logLevelOutputReceivedInvocations[2].level, .compact)
@@ -684,10 +683,10 @@ extension WarmupManagerTests {
         }
         XCTAssertEqual(downloadBinaryInvocations.count, 2)
         XCTAssertEqual(downloadBinaryInvocations[0].url.absoluteString,
-                       "https://s3.eu-west-2.amazonaws.com/LocalPod/Debug-iphonesimulator-arm64/b3035c7.\(archiveType.rawValue)")
+                       "https://s3.eu-west-2.amazonaws.com/LocalPod/Debug-iphonesimulator-arm64/b3035c7.\(archiveType)")
         XCTAssertEqual(downloadBinaryInvocations[0].headers, ["test_field": "test_value"])
         XCTAssertEqual(downloadBinaryInvocations[1].url.absoluteString,
-                       "https://s3.eu-west-2.amazonaws.com/SnapKit/Debug-iphonesimulator-arm64/eb56c2f.\(archiveType.rawValue)")
+                       "https://s3.eu-west-2.amazonaws.com/SnapKit/Debug-iphonesimulator-arm64/eb56c2f.\(archiveType)")
         XCTAssertEqual(downloadBinaryInvocations[1].headers, ["test_field": "test_value"])
 
         XCTAssertEqual(logger.logLevelOutputReceivedInvocations[3].text, "Found Remotely: 66% (2/3)")

--- a/Tests/FoundationTests/Core/Warmup/WarmupManagerTests.swift
+++ b/Tests/FoundationTests/Core/Warmup/WarmupManagerTests.swift
@@ -75,6 +75,7 @@ extension WarmupManagerTests {
                 mode: .analyse(endpoint: endpoint),
                 targetsOptions: .init(),
                 options: .mock(),
+                archiveType: .zip,
                 maxInParallel: 10,
                 headers: [:]
             )
@@ -97,6 +98,7 @@ extension WarmupManagerTests {
                 mode: .analyse(endpoint: nil),
                 targetsOptions: .init(),
                 options: .mock(),
+                archiveType: .zip,
                 maxInParallel: 10,
                 headers: [:]
             )
@@ -119,6 +121,7 @@ extension WarmupManagerTests {
                 mode: .analyse(endpoint: nil),
                 targetsOptions: .init(),
                 options: .mock(),
+                archiveType: .zip,
                 maxInParallel: 10,
                 headers: [:]
             )
@@ -160,6 +163,7 @@ extension WarmupManagerTests {
                 exceptTargetsRegex: exceptTargetsRegex
             ),
             options: xcodeBuildOptions,
+            archiveType: .zip,
             maxInParallel: 10,
             headers: [:]
         )
@@ -247,6 +251,7 @@ extension WarmupManagerTests {
                 exceptTargetsRegex: exceptTargetsRegex
             ),
             options: xcodeBuildOptions,
+            archiveType: .zip,
             maxInParallel: 10,
             headers: [:]
         )
@@ -310,7 +315,15 @@ extension WarmupManagerTests {
 // MARK: - Analyse with endpoint
 
 extension WarmupManagerTests {
-    func test_analyse_endpoint() async throws {
+    func test_analyseEndpointZip() async throws {
+        try await self.analyse_endpoint(archiveType: .zip)
+    }
+    
+    func test_analyseEndpoint7z() async throws {
+        try await self.analyse_endpoint(archiveType: .sevenZip)
+    }
+    
+    func analyse_endpoint(archiveType: ArchiveType) async throws {
         let targetsRegex = try NSRegularExpression(pattern: "^Alamofire|SnapKit$")
         let exceptTargetsRegex = try NSRegularExpression(pattern: "^Moya$")
         let endpoint = "s3.eu-west-2.amazonaws.com"
@@ -354,9 +367,9 @@ extension WarmupManagerTests {
         }
         cacheDownloader.checkIfBinaryIsReachableUrlHeadersClosure = { url, _ in
             switch url.absoluteString {
-            case "https://s3.eu-west-2.amazonaws.com/SnapKit/Debug-iphonesimulator-arm64/eb56c2f.zip":
+            case "https://s3.eu-west-2.amazonaws.com/SnapKit/Debug-iphonesimulator-arm64/eb56c2f.\(archiveType.rawValue)":
                 return true
-            case "https://s3.eu-west-2.amazonaws.com/Alamofire/Debug-iphonesimulator-arm64/dbe4415.zip":
+            case "https://s3.eu-west-2.amazonaws.com/Alamofire/Debug-iphonesimulator-arm64/dbe4415.\(archiveType.rawValue)":
                 return false
             default: fatalError()
             }
@@ -370,6 +383,7 @@ extension WarmupManagerTests {
                 exceptTargetsRegex: exceptTargetsRegex
             ),
             options: xcodeBuildOptions,
+            archiveType: archiveType,
             maxInParallel: 10,
             headers: [:]
         )
@@ -437,11 +451,11 @@ extension WarmupManagerTests {
         let sortedReachableInvocations = reachableInvocations.sorted { $0.url.absoluteString < $1.url.absoluteString }
         XCTAssertEqual(
             sortedReachableInvocations[0].url.absoluteString,
-            "https://s3.eu-west-2.amazonaws.com/Alamofire/Debug-iphonesimulator-arm64/dbe4415.zip"
+            "https://s3.eu-west-2.amazonaws.com/Alamofire/Debug-iphonesimulator-arm64/dbe4415.\(archiveType.rawValue)"
         )
         XCTAssertEqual(
             sortedReachableInvocations[1].url.absoluteString,
-            "https://s3.eu-west-2.amazonaws.com/SnapKit/Debug-iphonesimulator-arm64/eb56c2f.zip"
+            "https://s3.eu-west-2.amazonaws.com/SnapKit/Debug-iphonesimulator-arm64/eb56c2f.\(archiveType.rawValue)"
         )
         XCTAssertEqual(loggerBlockInvocations[3].header, "Checking binaries reachability")
         XCTAssertNil(loggerBlockInvocations[3].footer)
@@ -453,7 +467,7 @@ extension WarmupManagerTests {
             logger.logLevelOutputReceivedInvocations[2].text,
             """
             Unreachable:
-            https://s3.eu-west-2.amazonaws.com/Alamofire/Debug-iphonesimulator-arm64/dbe4415.zip
+            https://s3.eu-west-2.amazonaws.com/Alamofire/Debug-iphonesimulator-arm64/dbe4415.\(archiveType.rawValue)
             """
         )
         XCTAssertEqual(logger.logLevelOutputReceivedInvocations[2].level, .compact)
@@ -472,7 +486,16 @@ extension WarmupManagerTests {
 // MARK: - General
 
 extension WarmupManagerTests {
-    func test() async throws {
+    
+    func test_common_test_zip() async throws {
+        try await self.common_test(archiveType: .zip)
+    }
+    
+    func test_common_test_7z() async throws {
+        try await self.common_test(archiveType: .sevenZip)
+    }
+    
+    func common_test(archiveType: ArchiveType) async throws {
         let targetsRegex = try NSRegularExpression(pattern: "^Alamofire|SnapKit$")
         let exceptTargetsRegex = try NSRegularExpression(pattern: "^Moya$")
         let endpoint = "s3.eu-west-2.amazonaws.com"
@@ -523,20 +546,20 @@ extension WarmupManagerTests {
         }
         cacheDownloader.checkIfBinaryIsReachableUrlHeadersClosure = { url, _ in
             switch url.absoluteString {
-            case "https://s3.eu-west-2.amazonaws.com/SnapKit/Debug-iphonesimulator-arm64/eb56c2f.zip":
+            case "https://s3.eu-west-2.amazonaws.com/SnapKit/Debug-iphonesimulator-arm64/eb56c2f.\(archiveType.rawValue)":
                 return true
-            case "https://s3.eu-west-2.amazonaws.com/Alamofire/Debug-iphonesimulator-arm64/dbe4415.zip":
+            case "https://s3.eu-west-2.amazonaws.com/Alamofire/Debug-iphonesimulator-arm64/dbe4415.\(archiveType.rawValue)":
                 return false
-            case "https://s3.eu-west-2.amazonaws.com/LocalPod/Debug-iphonesimulator-arm64/b3035c7.zip":
+            case "https://s3.eu-west-2.amazonaws.com/LocalPod/Debug-iphonesimulator-arm64/b3035c7.\(archiveType.rawValue)":
                 return true
             default: fatalError()
             }
         }
         cacheDownloader.downloadBinaryUrlHeadersToClosure = { url, _, _ in
             switch url.absoluteString {
-            case "https://s3.eu-west-2.amazonaws.com/LocalPod/Debug-iphonesimulator-arm64/b3035c7.zip":
+            case "https://s3.eu-west-2.amazonaws.com/LocalPod/Debug-iphonesimulator-arm64/b3035c7.\(archiveType.rawValue)":
                 return true
-            case "https://s3.eu-west-2.amazonaws.com/SnapKit/Debug-iphonesimulator-arm64/eb56c2f.zip":
+            case "https://s3.eu-west-2.amazonaws.com/SnapKit/Debug-iphonesimulator-arm64/eb56c2f.\(archiveType.rawValue)":
                 return false
             default: fatalError()
             }
@@ -550,6 +573,7 @@ extension WarmupManagerTests {
                 exceptTargetsRegex: exceptTargetsRegex
             ),
             options: xcodeBuildOptions,
+            archiveType: archiveType,
             maxInParallel: 10,
             headers: ["test_field": "test_value"]
         )
@@ -620,17 +644,17 @@ extension WarmupManagerTests {
         let sortedReachableInvocations = reachableInvocations.sorted { $0.url.absoluteString < $1.url.absoluteString }
         XCTAssertEqual(
             sortedReachableInvocations[0].url.absoluteString,
-            "https://s3.eu-west-2.amazonaws.com/Alamofire/Debug-iphonesimulator-arm64/dbe4415.zip"
+            "https://s3.eu-west-2.amazonaws.com/Alamofire/Debug-iphonesimulator-arm64/dbe4415.\(archiveType.rawValue)"
         )
         XCTAssertEqual(sortedReachableInvocations[0].headers, ["test_field": "test_value"])
         XCTAssertEqual(
             sortedReachableInvocations[1].url.absoluteString,
-            "https://s3.eu-west-2.amazonaws.com/LocalPod/Debug-iphonesimulator-arm64/b3035c7.zip"
+            "https://s3.eu-west-2.amazonaws.com/LocalPod/Debug-iphonesimulator-arm64/b3035c7.\(archiveType.rawValue)"
         )
         XCTAssertEqual(sortedReachableInvocations[1].headers, ["test_field": "test_value"])
         XCTAssertEqual(
             sortedReachableInvocations[2].url.absoluteString,
-            "https://s3.eu-west-2.amazonaws.com/SnapKit/Debug-iphonesimulator-arm64/eb56c2f.zip"
+            "https://s3.eu-west-2.amazonaws.com/SnapKit/Debug-iphonesimulator-arm64/eb56c2f.\(archiveType.rawValue)"
         )
         XCTAssertEqual(sortedReachableInvocations[2].headers, ["test_field": "test_value"])
         XCTAssertEqual(loggerBlockInvocations[3].header, "Checking binaries reachability")
@@ -643,7 +667,7 @@ extension WarmupManagerTests {
             logger.logLevelOutputReceivedInvocations[2].text,
             """
             Unreachable:
-            https://s3.eu-west-2.amazonaws.com/Alamofire/Debug-iphonesimulator-arm64/dbe4415.zip
+            https://s3.eu-west-2.amazonaws.com/Alamofire/Debug-iphonesimulator-arm64/dbe4415.\(archiveType.rawValue)
             """
         )
         XCTAssertEqual(logger.logLevelOutputReceivedInvocations[2].level, .compact)
@@ -660,10 +684,10 @@ extension WarmupManagerTests {
         }
         XCTAssertEqual(downloadBinaryInvocations.count, 2)
         XCTAssertEqual(downloadBinaryInvocations[0].url.absoluteString,
-                       "https://s3.eu-west-2.amazonaws.com/LocalPod/Debug-iphonesimulator-arm64/b3035c7.zip")
+                       "https://s3.eu-west-2.amazonaws.com/LocalPod/Debug-iphonesimulator-arm64/b3035c7.\(archiveType.rawValue)")
         XCTAssertEqual(downloadBinaryInvocations[0].headers, ["test_field": "test_value"])
         XCTAssertEqual(downloadBinaryInvocations[1].url.absoluteString,
-                       "https://s3.eu-west-2.amazonaws.com/SnapKit/Debug-iphonesimulator-arm64/eb56c2f.zip")
+                       "https://s3.eu-west-2.amazonaws.com/SnapKit/Debug-iphonesimulator-arm64/eb56c2f.\(archiveType.rawValue)")
         XCTAssertEqual(downloadBinaryInvocations[1].headers, ["test_field": "test_value"])
 
         XCTAssertEqual(logger.logLevelOutputReceivedInvocations[3].text, "Found Remotely: 66% (2/3)")

--- a/Tests/RugbyTests/Commands/Basic/WarmupTests.swift
+++ b/Tests/RugbyTests/Commands/Basic/WarmupTests.swift
@@ -1,7 +1,7 @@
- @testable import Rugby
- import XCTest
+@testable import Rugby
+import XCTest
 
- final class WarmupTests: XCTestCase {
+final class WarmupTests: XCTestCase {
     func test_headersParsing_two() {
         let headers = ["X-First-Name: Joe", "User-Agent: yes-please/2000"].parseHeaders()
 
@@ -17,4 +17,4 @@
         XCTAssertEqual([].parseHeaders(), [:])
         XCTAssertEqual([""].parseHeaders(), [:])
     }
- }
+}

--- a/Tests/RugbyTests/Commands/Basic/WarmupTests.swift
+++ b/Tests/RugbyTests/Commands/Basic/WarmupTests.swift
@@ -1,20 +1,20 @@
-// @testable import Rugby
-// import XCTest
-//
-// final class WarmupTests: XCTestCase {
-//    func test_headersParsing_two() {
-//        let headers = ["X-First-Name: Joe", "User-Agent: yes-please/2000"].parseHeaders()
-//
-//        // Assert
-//        XCTAssertEqual(headers.count, 2)
-//        XCTAssertEqual(headers["X-First-Name"], "Joe")
-//        XCTAssertEqual(headers["User-Agent"], "yes-please/2000")
-//    }
-//
-//    func test_headersParsing() {
-//        XCTAssertEqual(["User-Agent: yes-please/2000"].parseHeaders(), ["User-Agent": "yes-please/2000"])
-//        XCTAssertEqual(["User-Agent:yes-please/2000"].parseHeaders(), [:])
-//        XCTAssertEqual([].parseHeaders(), [:])
-//        XCTAssertEqual([""].parseHeaders(), [:])
-//    }
-// }
+ @testable import Rugby
+ import XCTest
+
+ final class WarmupTests: XCTestCase {
+    func test_headersParsing_two() {
+        let headers = ["X-First-Name: Joe", "User-Agent: yes-please/2000"].parseHeaders()
+
+        // Assert
+        XCTAssertEqual(headers.count, 2)
+        XCTAssertEqual(headers["X-First-Name"], "Joe")
+        XCTAssertEqual(headers["User-Agent"], "yes-please/2000")
+    }
+
+    func test_headersParsing() {
+        XCTAssertEqual(["User-Agent: yes-please/2000"].parseHeaders(), ["User-Agent": "yes-please/2000"])
+        XCTAssertEqual(["User-Agent:yes-please/2000"].parseHeaders(), [:])
+        XCTAssertEqual([].parseHeaders(), [:])
+        XCTAssertEqual([""].parseHeaders(), [:])
+    }
+ }


### PR DESCRIPTION
### Description
There is implementation of different archive type to store. Why 7z? Because it is more efficient than zip, compressor use more than one CPU core and utilize them better. Archives become smaller, approximately by 30% percent.

I used library and passed archive type in CommonOptions, because i think that it is common parameter to control whole Rugby

### References
There is difference for archives sizes between zip and 7z. For test i uploaded binaries with both types
<img width="907" alt="Снимок экрана 2024-04-22 в 14 00 20" src="https://github.com/swiftyfinch/Rugby/assets/1080044/4aff988a-77ca-4125-b986-1a8541f073ae">


### Checklist (I have ...)
- [x] 🧐 Followed the code style of the rest of the project
- [ ] 📖 Updated the documentation, if necessary
- [x] 👨🏻‍🔧 Added at least one test which validates that my change is working, if appropriate
- [x] 👮🏻‍♂️ Run `make lint` and fixed all warnings
- [x] ✅ Run `make test` and fixed all tests

❤️ Thanks for contributing to the 🏈 Rugby!
