### PR TITLE
Include Xcode version in target's hashes

### DIFF
--- a/Sources/RugbyFoundation/Core/Common/Hashers/TargetsHasher.swift
+++ b/Sources/RugbyFoundation/Core/Common/Hashers/TargetsHasher.swift
@@ -13,6 +13,7 @@ protocol ITargetsHasher: AnyObject {
 final class TargetsHasher {
     private let foundationHasher: FoundationHasher
     private let swiftVersionProvider: ISwiftVersionProvider
+    private let xcodeCLTVersionProvider: IXcodeCLTVersionProvider
     private let buildPhaseHasher: IBuildPhaseHasher
     private let cocoaPodsScriptsHasher: ICocoaPodsScriptsHasher
     private let configurationsHasher: IConfigurationsHasher
@@ -21,6 +22,7 @@ final class TargetsHasher {
 
     init(foundationHasher: FoundationHasher,
          swiftVersionProvider: ISwiftVersionProvider,
+         xcodeCLTVersionProvider: IXcodeCLTVersionProvider,
          buildPhaseHasher: IBuildPhaseHasher,
          cocoaPodsScriptsHasher: ICocoaPodsScriptsHasher,
          configurationsHasher: IConfigurationsHasher,
@@ -28,6 +30,7 @@ final class TargetsHasher {
          buildRulesHasher: IBuildRulesHasher) {
         self.foundationHasher = foundationHasher
         self.swiftVersionProvider = swiftVersionProvider
+        self.xcodeCLTVersionProvider = xcodeCLTVersionProvider
         self.buildPhaseHasher = buildPhaseHasher
         self.cocoaPodsScriptsHasher = cocoaPodsScriptsHasher
         self.configurationsHasher = configurationsHasher
@@ -61,6 +64,7 @@ final class TargetsHasher {
         try await [
             "name": target.name,
             "swift_version": swiftVersionProvider.swiftVersion(),
+            "xcode_version": String(describing: xcodeCLTVersionProvider.version()),
             "buildOptions": [
                 "xcargs": xcargs.sorted()
             ],

--- a/Sources/RugbyFoundation/Core/Env/XcodeCLTVersionProvider.swift
+++ b/Sources/RugbyFoundation/Core/Env/XcodeCLTVersionProvider.swift
@@ -2,8 +2,20 @@ import Foundation
 
 // MARK: - Interface
 
-protocol IXcodeCLTVersionProvider: AnyObject {
-    func version() throws -> (base: String, build: String?)
+public protocol IXcodeCLTVersionProvider: AnyObject {
+    func version() throws -> XcodeVersion
+}
+
+/// Representation of an Xcode version
+public struct XcodeVersion {
+    let base: String
+    let build: String?
+}
+
+extension XcodeVersion: CustomStringConvertible {
+    public var description: String {
+        "Xcode \(base) - Build version \(build ?? "unknown")"
+    }
 }
 
 enum XcodeCLTVersionProviderError: LocalizedError {
@@ -25,7 +37,7 @@ enum XcodeCLTVersionProviderError: LocalizedError {
 final class XcodeCLTVersionProvider {
     private typealias Error = XcodeCLTVersionProviderError
     private let shellExecutor: IShellExecutor
-    private var cachedXcodeVersion: (base: String, build: String?)?
+    private var cachedXcodeVersion: XcodeVersion?
 
     init(shellExecutor: IShellExecutor) {
         self.shellExecutor = shellExecutor
@@ -35,7 +47,7 @@ final class XcodeCLTVersionProvider {
 // MARK: - IXcodeCLTVersionProvider
 
 extension XcodeCLTVersionProvider: IXcodeCLTVersionProvider {
-    func version() throws -> (base: String, build: String?) {
+    func version() throws -> XcodeVersion {
         if let cachedXcodeVersion { return cachedXcodeVersion }
 
         guard let output = try? shellExecutor.throwingShell("xcodebuild -version")?
@@ -43,11 +55,11 @@ extension XcodeCLTVersionProvider: IXcodeCLTVersionProvider {
             .filter({ !$0.isEmpty })
         else { throw XcodeCLTVersionProviderError.unknownXcodeCLT }
 
-        let version: (base: String, build: String?)
+        let version: XcodeVersion
         if output.count == 2 {
-            version = (output[0], output[1])
+            version = XcodeVersion(base: output[0], build: output[1])
         } else {
-            version = (output.joined(separator: " - "), nil)
+            version = XcodeVersion(base: output.joined(separator: " - "), build: nil)
         }
         cachedXcodeVersion = version
         return version

--- a/Sources/RugbyFoundation/Vault/Vault.swift
+++ b/Sources/RugbyFoundation/Vault/Vault.swift
@@ -69,6 +69,11 @@ public final class Vault {
         shellExecutor: shellExecutor
     )
 
+    /// The service providing the current Xcode version.
+    public private(set) lazy var xcodeCLTVersionProvider: IXcodeCLTVersionProvider = XcodeCLTVersionProvider(
+        shellExecutor: shellExecutor
+    )
+
     /// The service providing the current CPU architecture.
     public private(set) lazy var architectureProvider: IArchitectureProvider = ArchitectureProvider(
         shellExecutor: shellExecutor
@@ -122,6 +127,7 @@ public final class Vault {
         return TargetsHasher(
             foundationHasher: foundationHasher,
             swiftVersionProvider: swiftVersionProvider,
+            xcodeCLTVersionProvider: xcodeCLTVersionProvider,
             buildPhaseHasher: BuildPhaseHasher(
                 logger: logger,
                 workingDirectoryPath: router.workingDirectory.path,

--- a/Tests/FoundationTests/Core/Common/Hashers/TargetsHasherTests.swift
+++ b/Tests/FoundationTests/Core/Common/Hashers/TargetsHasherTests.swift
@@ -5,6 +5,7 @@ final class TargetsHasherTests: XCTestCase {
     private var sut: ITargetsHasher!
     private var foundationHasher: FoundationHasherMock!
     private var swiftVersionProvider: ISwiftVersionProviderMock!
+    private var xcodeCLTVersionProvider: IXcodeCLTVersionProviderMock!
     private var buildPhaseHasher: IBuildPhaseHasherMock!
     private var cocoaPodsScriptsHasher: ICocoaPodsScriptsHasherMock!
     private var configurationsHasher: IConfigurationsHasherMock!
@@ -15,6 +16,7 @@ final class TargetsHasherTests: XCTestCase {
         super.setUp()
         foundationHasher = FoundationHasherMock()
         swiftVersionProvider = ISwiftVersionProviderMock()
+        xcodeCLTVersionProvider = IXcodeCLTVersionProviderMock()
         buildPhaseHasher = IBuildPhaseHasherMock()
         cocoaPodsScriptsHasher = ICocoaPodsScriptsHasherMock()
         configurationsHasher = IConfigurationsHasherMock()
@@ -23,6 +25,7 @@ final class TargetsHasherTests: XCTestCase {
         sut = TargetsHasher(
             foundationHasher: foundationHasher,
             swiftVersionProvider: swiftVersionProvider,
+            xcodeCLTVersionProvider: xcodeCLTVersionProvider,
             buildPhaseHasher: buildPhaseHasher,
             cocoaPodsScriptsHasher: cocoaPodsScriptsHasher,
             configurationsHasher: configurationsHasher,
@@ -35,6 +38,7 @@ final class TargetsHasherTests: XCTestCase {
         super.tearDown()
         foundationHasher = nil
         swiftVersionProvider = nil
+        xcodeCLTVersionProvider = nil
         buildPhaseHasher = nil
         cocoaPodsScriptsHasher = nil
         configurationsHasher = nil
@@ -62,7 +66,8 @@ extension TargetsHasherTests {
         dependencies: {}
         name: Alamofire-framework
         product: null
-        swift_version: \'5.9\'\n
+        swift_version: \'5.9\'
+        xcode_version: Xcode 14.5 - Build version 1234\n
         """
         let alamofire = IInternalTargetMock()
         alamofire.underlyingName = "Alamofire-framework"
@@ -87,7 +92,8 @@ extension TargetsHasherTests {
         name: Moya-framework
         product:
           MoyaProduct: MoyaProduct_hash
-        swift_version: \'5.9\'\n
+        swift_version: \'5.9\'
+        xcode_version: Xcode 14.5 - Build version 1234\n
         """
         let moya = IInternalTargetMock()
         moya.underlyingName = "Moya-framework"
@@ -112,7 +118,8 @@ extension TargetsHasherTests {
         dependencies: {}
         name: LocalPod-framework-LocalPodResources
         product: null
-        swift_version: \'5.9\'\n
+        swift_version: \'5.9\'
+        xcode_version: Xcode 14.5 - Build version 1234\n
         """
         let localPodResources = IInternalTargetMock()
         localPodResources.underlyingName = "LocalPod-framework-LocalPodResources"
@@ -138,7 +145,8 @@ extension TargetsHasherTests {
           Moya-framework: Moya_hashed
         name: LocalPod-framework
         product: null
-        swift_version: \'5.9\'\n
+        swift_version: \'5.9\'
+        xcode_version: Xcode 14.5 - Build version 1234\n
         """
         let localPod = IInternalTargetMock()
         localPod.underlyingName = "LocalPod-framework"
@@ -156,6 +164,8 @@ extension TargetsHasherTests {
             moya.uuid: moya,
             localPodResources.uuid: localPodResources
         ]
+
+        xcodeCLTVersionProvider.versionReturnValue = XcodeVersion(base: "14.5", build: "1234")
 
         await swiftVersionProvider.setSwiftVersionReturnValue("5.9")
         configurationsHasher.hashContextClosure = { ["\($0.name)_configuration_hash"] }
@@ -229,7 +239,7 @@ extension TargetsHasherTests {
         buildPhaseHasher.hashContextTargetReturnValue = []
         foundationHasher.hashArrayOfStringsReturnValue = "test_rehash_array"
         foundationHasher.hashStringReturnValue = "test_rehash"
-
+        xcodeCLTVersionProvider.versionReturnValue = XcodeVersion(base: "14.5", build: "1234")
         // Act
         try await sut.hash(targets, xcargs: [], rehash: true)
 
@@ -246,7 +256,8 @@ extension TargetsHasherTests {
             dependencies: {}
             name: Alamofire-framework
             product: null
-            swift_version: \'5.9\'\n
+            swift_version: \'5.9\'
+            xcode_version: Xcode 14.5 - Build version 1234\n
             """
         )
         XCTAssertEqual(alamofire.hash, "test_rehash")

--- a/Tests/FoundationTests/Core/Env/EnvironmentCollectorTests.swift
+++ b/Tests/FoundationTests/Core/Env/EnvironmentCollectorTests.swift
@@ -47,7 +47,7 @@ final class EnvironmentCollectorTests: XCTestCase {
 
 extension EnvironmentCollectorTests {
     func test_env() async throws {
-        xcodeCLTVersionProvider.versionReturnValue = ("Xcode 15.0", "Build version 15A240d")
+        xcodeCLTVersionProvider.versionReturnValue = XcodeVersion(base: "Xcode 15.0", build: "Build version 15A240d")
         architectureProvider.architectureReturnValue = .arm64
         await swiftVersionProvider.setSwiftVersionReturnValue("5.9")
         shellExecutor.throwingShellArgsClosure = { command, _ in
@@ -92,7 +92,7 @@ extension EnvironmentCollectorTests {
 
     func test_write() async throws {
         Rainbow.enabled = false
-        xcodeCLTVersionProvider.versionReturnValue = ("Xcode 15.0", "Build version 15A240d")
+        xcodeCLTVersionProvider.versionReturnValue = XcodeVersion(base: "Xcode 15.0", build: "Build version 15A240d")
         await swiftVersionProvider.setSwiftVersionReturnValue("5.9")
         architectureProvider.architectureReturnValue = .auto
         struct Build {
@@ -136,7 +136,7 @@ extension EnvironmentCollectorTests {
 
     func test_logXcodeVersion() async throws {
         Rainbow.enabled = true
-        xcodeCLTVersionProvider.versionReturnValue = ("Xcode 15.0", "Build version 15A240d")
+        xcodeCLTVersionProvider.versionReturnValue = XcodeVersion(base: "Xcode 15.0", build: "Build version 15A240d")
 
         // Act
         try await sut.logXcodeVersion()

--- a/Tests/FoundationTests/Mocks/IXcodeCLTVersionProviderMock.generated.swift
+++ b/Tests/FoundationTests/Mocks/IXcodeCLTVersionProviderMock.generated.swift
@@ -6,17 +6,19 @@
 import Foundation
 @testable import RugbyFoundation
 
-final class IXcodeCLTVersionProviderMock: IXcodeCLTVersionProvider {
+public final class IXcodeCLTVersionProviderMock: IXcodeCLTVersionProvider {
+
+    public init() {}
 
     // MARK: - version
 
-    var versionThrowableError: Error?
-    var versionCallsCount = 0
-    var versionCalled: Bool { versionCallsCount > 0 }
-    var versionReturnValue: (base: String, build: String?)!
-    var versionClosure: (() throws -> (base: String, build: String?))?
+    public var versionThrowableError: Error?
+    public var versionCallsCount = 0
+    public var versionCalled: Bool { versionCallsCount > 0 }
+    public var versionReturnValue: XcodeVersion!
+    public var versionClosure: (() throws -> XcodeVersion)?
 
-    func version() throws -> (base: String, build: String?) {
+    public func version() throws -> XcodeVersion {
         versionCallsCount += 1
         if let error = versionThrowableError {
             throw error


### PR DESCRIPTION
<!--
  Hello!

  Before you submit your request, please replace the paragraph
  below with the relevant details, and complete the steps in the
  checklist by placing an 'x' in each box:

  - [x] I've completed this task
  - [ ] This task isn't completed

  Provide links to an existing issue or external references/discussions, if appropriate.
-->

### Description
<!--Please describe your pull request.-->
This PR extends the hashing of the targets to include the Xcode version used to build. This addresses an issue in which caches built with a specific SDK will cause compilation errors when trying to build a project with a different Xcode version, as described in the linked discussion in the references section below.

I have taken some decisions that I am more than happy to change if the maintainer of the tool prefers a different approach. I will mark these decisions as comments in the pull request.

### References
<!--Provide links to an existing issue or external references/discussions, if appropriate.-->
https://github.com/swiftyfinch/Rugby/discussions/393

### Checklist (I have ...)
- [x] 🧐 Followed the code style of the rest of the project
- [x] 📖 Updated the documentation, if necessary (N/A)
- [x] 👨🏻‍🔧 Added at least one test which validates that my change is working, if appropriate (updated existing tests)
- [x] 👮🏻‍♂️ Run `make lint` and fixed all warnings
- [x] ✅ Run `make test` and fixed all tests

❤️ Thanks for contributing to the 🏈 Rugby!
