### PR TITLE
Change format of xcode version

### DIFF
--- a/Sources/RugbyFoundation/Core/Env/EnvironmentCollector.swift
+++ b/Sources/RugbyFoundation/Core/Env/EnvironmentCollector.swift
@@ -107,7 +107,7 @@ extension EnvironmentCollector: IEnvironmentCollector {
         var output = try [
             "Rugby version: \(rugbyVersion)",
             await getSwiftVersion(),
-            "CLT: \(xcodeCLTVersion)",
+            "CLT: Xcode \(xcodeCLTVersion)",
             getCPU(),
             getProject(),
             getGitBranch()
@@ -135,7 +135,7 @@ extension EnvironmentCollector: IEnvironmentCollector {
     }
 
     public func logXcodeVersion() async throws {
-        try await log("CLT: \(xcodeCLTVersionProvider.version().base)")
+        try await log("CLT: Xcode \(xcodeCLTVersionProvider.version().base)")
     }
 
     public func logCommandDump(command: some Any) async {

--- a/Sources/RugbyFoundation/Core/Env/XcodeCLTVersionProvider.swift
+++ b/Sources/RugbyFoundation/Core/Env/XcodeCLTVersionProvider.swift
@@ -30,7 +30,11 @@ enum XcodeCLTVersionProviderError: LocalizedError {
 
 final class XcodeCLTVersionProvider {
     private typealias Error = XcodeCLTVersionProviderError
+
     private let shellExecutor: IShellExecutor
+
+    private let xcodeVersionPrefix = "Xcode "
+    private let buildVersionPrefix = "Build version "
     private var cachedXcodeVersion: XcodeVersion?
 
     init(shellExecutor: IShellExecutor) {
@@ -51,9 +55,11 @@ extension XcodeCLTVersionProvider: IXcodeCLTVersionProvider {
 
         let version: XcodeVersion
         if output.count == 2 {
-            version = XcodeVersion(base: output[0], build: output[1])
+            let xcodeVersion = String(output[0].trimmingPrefix(xcodeVersionPrefix))
+            let buildVersion = String(output[1].trimmingPrefix(buildVersionPrefix))
+            version = XcodeVersion(base: xcodeVersion, build: buildVersion)
         } else {
-            version = XcodeVersion(base: output.joined(separator: " - "), build: nil)
+            version = XcodeVersion(base: output.joined(separator: " / "), build: nil)
         }
         cachedXcodeVersion = version
         return version

--- a/Tests/FoundationTests/Core/Env/EnvironmentCollectorTests.swift
+++ b/Tests/FoundationTests/Core/Env/EnvironmentCollectorTests.swift
@@ -47,7 +47,7 @@ final class EnvironmentCollectorTests: XCTestCase {
 
 extension EnvironmentCollectorTests {
     func test_env() async throws {
-        xcodeCLTVersionProvider.versionReturnValue = XcodeVersion(base: "Xcode 15.0", build: "Build version 15A240d")
+        xcodeCLTVersionProvider.versionReturnValue = XcodeVersion(base: "15.0", build: "15A240d")
         architectureProvider.architectureReturnValue = .arm64
         await swiftVersionProvider.setSwiftVersionReturnValue("5.9")
         shellExecutor.throwingShellArgsClosure = { command, _ in
@@ -80,7 +80,7 @@ extension EnvironmentCollectorTests {
             [
                 "Rugby version: 2.2.0",
                 "Swift: 5.9",
-                "CLT: Xcode 15.0 (Build version 15A240d)",
+                "CLT: Xcode 15.0 (15A240d)",
                 "CPU: Apple M1 Max (arm64)",
                 "Project: Example",
                 "Git branch: main",
@@ -92,7 +92,7 @@ extension EnvironmentCollectorTests {
 
     func test_write() async throws {
         Rainbow.enabled = false
-        xcodeCLTVersionProvider.versionReturnValue = XcodeVersion(base: "Xcode 15.0", build: "Build version 15A240d")
+        xcodeCLTVersionProvider.versionReturnValue = XcodeVersion(base: "15.0", build: "15A240d")
         await swiftVersionProvider.setSwiftVersionReturnValue("5.9")
         architectureProvider.architectureReturnValue = .auto
         struct Build {
@@ -121,7 +121,7 @@ extension EnvironmentCollectorTests {
             [
                 "Rugby version: 2.0",
                 "Swift: 5.9",
-                "CLT: Xcode 15.0 (Build version 15A240d)",
+                "CLT: Xcode 15.0 (15A240d)",
                 "CPU: Unknown (auto)",
                 "Project: Unknown",
                 "Git branch: Unknown",
@@ -136,7 +136,7 @@ extension EnvironmentCollectorTests {
 
     func test_logXcodeVersion() async throws {
         Rainbow.enabled = true
-        xcodeCLTVersionProvider.versionReturnValue = XcodeVersion(base: "Xcode 15.0", build: "Build version 15A240d")
+        xcodeCLTVersionProvider.versionReturnValue = XcodeVersion(base: "15.0", build: "15A240d")
 
         // Act
         try await sut.logXcodeVersion()

--- a/Tests/FoundationTests/Core/Env/XcodeCLTVersionProviderTests.swift
+++ b/Tests/FoundationTests/Core/Env/XcodeCLTVersionProviderTests.swift
@@ -33,8 +33,8 @@ extension XcodeCLTVersionProviderTests {
         let versionInfo = try sut.version()
 
         // Assert
-        XCTAssertEqual(versionInfo.base, "Xcode 14.1")
-        XCTAssertEqual(versionInfo.build, "Build version 14B47b")
+        XCTAssertEqual(versionInfo.base, "14.1")
+        XCTAssertEqual(versionInfo.build, "14B47b")
         XCTAssertEqual(shellExecutorMock.throwingShellArgsCallsCount, 1)
     }
 
@@ -48,8 +48,8 @@ extension XcodeCLTVersionProviderTests {
         let versionInfo = try sut.version()
 
         // Assert
-        XCTAssertEqual(versionInfo.base, "Xcode 14.1.3")
-        XCTAssertEqual(versionInfo.build, "Build version 04BD7b")
+        XCTAssertEqual(versionInfo.base, "14.1.3")
+        XCTAssertEqual(versionInfo.build, "04BD7b")
         XCTAssertEqual(shellExecutorMock.throwingShellArgsCallsCount, 1)
     }
 
@@ -79,7 +79,7 @@ extension XcodeCLTVersionProviderTests {
         let versionInfo = try sut.version()
 
         // Assert
-        XCTAssertEqual(versionInfo.base, "Xcode 14.1.3 - Build - version - 04BD7b")
+        XCTAssertEqual(versionInfo.base, "Xcode 14.1.3 / Build / version / 04BD7b")
         XCTAssertNil(versionInfo.build)
         XCTAssertEqual(shellExecutorMock.throwingShellArgsCallsCount, 1)
     }
@@ -99,10 +99,10 @@ extension XcodeCLTVersionProviderTests {
         let versionInfoCache = try sut.version()
 
         // Assert
-        XCTAssertEqual(versionInfo.base, "Xcode 14.2")
-        XCTAssertEqual(versionInfo.build, "Build version 11BT7b")
-        XCTAssertEqual(versionInfoCache.base, "Xcode 14.2")
-        XCTAssertEqual(versionInfoCache.build, "Build version 11BT7b")
+        XCTAssertEqual(versionInfo.base, "14.2")
+        XCTAssertEqual(versionInfo.build, "11BT7b")
+        XCTAssertEqual(versionInfoCache.base, "14.2")
+        XCTAssertEqual(versionInfoCache.build, "11BT7b")
         XCTAssertEqual(shellExecutorMock.throwingShellArgsCallsCount, 1)
     }
 }


### PR DESCRIPTION
### Description
<!--Please describe your pull request.-->
I have changed the format of the Xcode base and the build versions.
```yml
# Before
xcode_version: Xcode 15.0.1 (Build version 15A507)
```
```yml
# After
xcode_version: 15.0.1 (15A507)
```

### References
<!--Provide links to an existing issue or external references/discussions, if appropriate.-->
- #395 

### Checklist (I have ...)
- [x] 🧐 Followed the code style of the rest of the project
- [ ] 📖 Updated the documentation, if necessary
- [ ] 👨🏻‍🔧 Added at least one test which validates that my change is working, if appropriate
- [x] 👮🏻‍♂️ Run `make lint` and fixed all warnings
- [x] ✅ Run `make test` and fixed all tests

❤️ Thanks for contributing to the 🏈 Rugby!
