### PR TITLE
Fix: Handle cases where search header path does not end with "Headers"

### DIFF
--- a/Sources/RugbyFoundation/Core/Build/XcodeBuild/XcodeBuild.swift
+++ b/Sources/RugbyFoundation/Core/Build/XcodeBuild/XcodeBuild.swift
@@ -99,7 +99,7 @@ final class XcodeBuild {
             "-project \(paths.project.shellFriendly)",
             "SYMROOT=\(paths.symroot.shellFriendly)"
         ])
-        options.resultBundlePath.map {
+        options.resultBundlePath.flatMap {
             arguments.append("-resultBundlePath \($0.shellFriendly)")
         }
         arguments.append(contentsOf: options.xcargs)

--- a/Sources/RugbyFoundation/Core/Common/Hashers/TargetsHasher.swift
+++ b/Sources/RugbyFoundation/Core/Common/Hashers/TargetsHasher.swift
@@ -72,7 +72,7 @@ final class TargetsHasher {
                 "xcargs": xcargs.sorted()
             ],
             "buildPhases": buildPhaseHasher.hashContext(target: target),
-            "product": target.product.map(productHasher.hashContext) as Any,
+            "product": target.product.flatMap(productHasher.hashContext) as Any,
             "configurations": configurationsHasher.hashContext(target),
             "cocoaPodsScripts": cocoaPodsScriptsHasher.hashContext(target),
             "buildRules": buildRulesHasher.hashContext(target.buildRules)
@@ -93,7 +93,7 @@ extension TargetsHasher: ITargetsHasher {
         targets.modifyIf(rehash) { resetHash($0) }
 
         let xcodeVersion = try xcodeCLTVersionProvider.version()
-        let formattedXcodeBuildVersion = xcodeVersion.build.map { " (\($0))" } ?? ""
+        let formattedXcodeBuildVersion = xcodeVersion.build.flatMap { " (\($0))" } ?? ""
         let formattedXcodeVersion = "\(xcodeVersion.base)" + formattedXcodeBuildVersion
         try await targets.merging(targets.flatMapValues(\.dependencies)).values.concurrentForEach { target in
             guard target.targetHashContext == nil else { return }

--- a/Sources/RugbyFoundation/Core/Env/EnvironmentCollector.swift
+++ b/Sources/RugbyFoundation/Core/Env/EnvironmentCollector.swift
@@ -103,7 +103,7 @@ extension EnvironmentCollector: IEnvironmentCollector {
         rugbyEnvironment: [String: String]
     ) async throws -> [String] {
         let xcodeCLTInfo = try xcodeCLTVersionProvider.version()
-        let xcodeCLTVersion = xcodeCLTInfo.build.map { "\(xcodeCLTInfo.base) (\($0))" } ?? xcodeCLTInfo.base
+        let xcodeCLTVersion = xcodeCLTInfo.build.flatMap { "\(xcodeCLTInfo.base) (\($0))" } ?? xcodeCLTInfo.base
         var output = try [
             "Rugby version: \(rugbyVersion)",
             await getSwiftVersion(),

--- a/Sources/RugbyFoundation/Core/Use/SupportFilesPatcher.swift
+++ b/Sources/RugbyFoundation/Core/Use/SupportFilesPatcher.swift
@@ -15,7 +15,7 @@ struct FileReplacement {
 
 enum ReplacementBoundary {
     static let prefix = #"(?<=(\"|'|\s))"#
-    static let suffix = #"(?=(\"|'|\s))"#
+    static let suffix = #"(?=(\"|'|\s|/))"#
 }
 
 protocol ISupportFilesPatcher: AnyObject {

--- a/Sources/RugbyFoundation/XcodeProject/Services/XcodeProjectDataSource.swift
+++ b/Sources/RugbyFoundation/XcodeProject/Services/XcodeProjectDataSource.swift
@@ -50,7 +50,7 @@ final class XcodeProjectDataSource: Loggable {
     func save() async throws {
         // Save only read projects
         var projects = cachedSubprojects ?? []
-        cachedRootProject.map { projects.append($0) }
+        cachedRootProject.flatMap { projects.append($0) }
 
         try await projects.concurrentMap { project in
             try project.xcodeProj.write(pathString: project.path, override: true)

--- a/Tests/FoundationTests/Core/Use/SupportFilesPatcherTests.swift
+++ b/Tests/FoundationTests/Core/Use/SupportFilesPatcherTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class SupportFilesPatcherTests: XCTestCase {
     private var sut: ISupportFilesPatcher!
     private var expectedPrefixBoundary = #"(?<=(\"|'|\s))"#
-    private var expectedSuffixBoundary = #"(?=(\"|'|\s))"#
+    private var expectedSuffixBoundary = #"(?=(\"|'|\s|/))"#
 
     override func setUp() {
         super.setUp()


### PR DESCRIPTION
<!--
  Hello!

  Before you submit your request, please replace the paragraph
  below with the relevant details, and complete the steps in the
  checklist by placing an 'x' in each box:

  - [x] I've completed this task
  - [ ] This task isn't completed

  Provide links to an existing issue or external references/discussions, if appropriate.
-->

### Description
<!--Please describe your pull request.-->
- Fixed issue with search header paths not ending with "Headers".
- Replaced incorrect usage of `map` with `flatMap` to resolve mapping error.

- ${PODS_CONFIGURATION_BUILD_DIR}/ReactCommon/ReactCommon.framework/Headers/react/nativemodule/core not changed to rugby

### References
<!--Provide links to an existing issue or external references/discussions, if appropriate.-->
https://github.com/facebook/react-native/blob/7278ff01d7a48607f67079ca4a4e435e3b7125bf/packages/react-native/React/CoreModules/React-CoreModules.podspec#L75


### Checklist (I have ...)
- [ ] 🧐 Followed the code style of the rest of the project
- [ ] 📖 Updated the documentation, if necessary
- [ ] 👨🏻‍🔧 Added at least one test which validates that my change is working, if appropriate
- [x] 👮🏻‍♂️ Run `make lint` and fixed all warnings
- [x] ✅ Run `make test` and fixed all tests

❤️ Thanks for contributing to the 🏈 Rugby!
