### PR TITLE
Reproduce build error with rugby example

### DIFF
--- a/Example/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example/Example.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		04E2710AA358CF6DAD3FA767 /* libPods-ExampleLibsTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 144482165AB3009C611A221F /* libPods-ExampleLibsTests.a */; };
 		1F4F5F3A995A7D3332143083 /* Pods_ExampleFrameworksTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9DCED2581A63972952C5F2D0 /* Pods_ExampleFrameworksTests.framework */; };
 		2308781B2A8D3D6900AEB6A7 /* ExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2308781A2A8D3D6900AEB6A7 /* ExampleApp.swift */; };
 		2308781D2A8D3D6900AEB6A7 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2308781C2A8D3D6900AEB6A7 /* ContentView.swift */; };
@@ -15,7 +14,8 @@
 		2322FDD92AD468EB00F56303 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2308781C2A8D3D6900AEB6A7 /* ContentView.swift */; };
 		2322FDDA2AD468EB00F56303 /* ExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2308781A2A8D3D6900AEB6A7 /* ExampleApp.swift */; };
 		2322FDE92AD4696D00F56303 /* ExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2308782E2A8D3E3A00AEB6A7 /* ExampleTests.swift */; };
-		3C4BF03E4A81DE4E6DACC02D /* libPods-ExampleLibs.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B6061D8ED9A72EB783A5BE9C /* libPods-ExampleLibs.a */; };
+		6A0E6942E3615F37A7C688C4 /* libPods-ExampleLibs.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B49326E490E27FCBFA53C5C5 /* libPods-ExampleLibs.a */; };
+		9154D06A9791719D0FF9048C /* libPods-ExampleLibsTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2FDE4428905573DC827934C6 /* libPods-ExampleLibsTests.a */; };
 		D16F4A2CC1C5807DD921D8CF /* Pods_ExampleFrameworks.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 46F83992F7EC25B3096BE7B0 /* Pods_ExampleFrameworks.framework */; };
 /* End PBXBuildFile section */
 
@@ -40,8 +40,9 @@
 		05D1092F28CAA5B540E60C66 /* Pods-ExampleFrameworkTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleFrameworkTests.release.xcconfig"; path = "Target Support Files/Pods-ExampleFrameworkTests/Pods-ExampleFrameworkTests.release.xcconfig"; sourceTree = "<group>"; };
 		0A4FB7241AE3AEE226DA99EC /* Pods-ExampleFramework.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleFramework.debug.xcconfig"; path = "Target Support Files/Pods-ExampleFramework/Pods-ExampleFramework.debug.xcconfig"; sourceTree = "<group>"; };
 		0B9895EA97AC5C385ADE412B /* Pods-ExampleFrameworksTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleFrameworksTests.debug.xcconfig"; path = "Target Support Files/Pods-ExampleFrameworksTests/Pods-ExampleFrameworksTests.debug.xcconfig"; sourceTree = "<group>"; };
-		144482165AB3009C611A221F /* libPods-ExampleLibsTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ExampleLibsTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		0EC70F0D1DE9F9E451734728 /* Pods-ExampleLibsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleLibsTests.release.xcconfig"; path = "Target Support Files/Pods-ExampleLibsTests/Pods-ExampleLibsTests.release.xcconfig"; sourceTree = "<group>"; };
 		190B134C89F814DE7FA304A7 /* Pods-Example-ExampleUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example-ExampleUITests.release.xcconfig"; path = "Target Support Files/Pods-Example-ExampleUITests/Pods-Example-ExampleUITests.release.xcconfig"; sourceTree = "<group>"; };
+		191DDE0D6BA6BE48040F162F /* Pods-ExampleLibsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleLibsTests.debug.xcconfig"; path = "Target Support Files/Pods-ExampleLibsTests/Pods-ExampleLibsTests.debug.xcconfig"; sourceTree = "<group>"; };
 		230878172A8D3D6900AEB6A7 /* ExampleFrameworks.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ExampleFrameworks.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2308781A2A8D3D6900AEB6A7 /* ExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleApp.swift; sourceTree = "<group>"; };
 		2308781C2A8D3D6900AEB6A7 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -49,23 +50,22 @@
 		2308782E2A8D3E3A00AEB6A7 /* ExampleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleTests.swift; sourceTree = "<group>"; };
 		2322FDE32AD468EB00F56303 /* ExampleLibs.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ExampleLibs.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2322FDF12AD4696D00F56303 /* ExampleLibsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExampleLibsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		2FDE4428905573DC827934C6 /* libPods-ExampleLibsTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ExampleLibsTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2FDF6380BEBD68849DCD6B9E /* Pods-ExampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleTests.release.xcconfig"; path = "Target Support Files/Pods-ExampleTests/Pods-ExampleTests.release.xcconfig"; sourceTree = "<group>"; };
 		3E07C42579D503D6CBF83C1E /* Pods_Example_ExampleUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Example_ExampleUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		46F83992F7EC25B3096BE7B0 /* Pods_ExampleFrameworks.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ExampleFrameworks.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		48C3D39CC5C27E9B13479331 /* Pods-ExampleLibs.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleLibs.release.xcconfig"; path = "Target Support Files/Pods-ExampleLibs/Pods-ExampleLibs.release.xcconfig"; sourceTree = "<group>"; };
-		6EE0FC5DD11F25E0210F3143 /* Pods-ExampleLibsTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleLibsTests.debug.xcconfig"; path = "Target Support Files/Pods-ExampleLibsTests/Pods-ExampleLibsTests.debug.xcconfig"; sourceTree = "<group>"; };
 		79D74EAF77CA9BBDE5F3EBDB /* Pods-ExampleFrameworks.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleFrameworks.release.xcconfig"; path = "Target Support Files/Pods-ExampleFrameworks/Pods-ExampleFrameworks.release.xcconfig"; sourceTree = "<group>"; };
+		8EF2FE1D5E34F824D8DF7AA8 /* Pods-ExampleLibs.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleLibs.release.xcconfig"; path = "Target Support Files/Pods-ExampleLibs/Pods-ExampleLibs.release.xcconfig"; sourceTree = "<group>"; };
 		969D03428C0B24E46DC48E68 /* Pods-ExampleFrameworkTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleFrameworkTests.debug.xcconfig"; path = "Target Support Files/Pods-ExampleFrameworkTests/Pods-ExampleFrameworkTests.debug.xcconfig"; sourceTree = "<group>"; };
 		97A6C05F3D9BBB13F3B19FD8 /* Pods-Example-ExampleUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example-ExampleUITests.debug.xcconfig"; path = "Target Support Files/Pods-Example-ExampleUITests/Pods-Example-ExampleUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		9DCED2581A63972952C5F2D0 /* Pods_ExampleFrameworksTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_ExampleFrameworksTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A6131BD03CC7E02A8CB89F62 /* Pods-ExampleFrameworks.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleFrameworks.debug.xcconfig"; path = "Target Support Files/Pods-ExampleFrameworks/Pods-ExampleFrameworks.debug.xcconfig"; sourceTree = "<group>"; };
+		A6A53AB767CB3288ECC596F5 /* Pods-ExampleLibs.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleLibs.debug.xcconfig"; path = "Target Support Files/Pods-ExampleLibs/Pods-ExampleLibs.debug.xcconfig"; sourceTree = "<group>"; };
 		A880AD8271321C709AF97527 /* Pods-ExampleTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleTests.debug.xcconfig"; path = "Target Support Files/Pods-ExampleTests/Pods-ExampleTests.debug.xcconfig"; sourceTree = "<group>"; };
 		A9BA1130682EAD2A4CC8DFD7 /* Pods-ExampleFramework.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleFramework.release.xcconfig"; path = "Target Support Files/Pods-ExampleFramework/Pods-ExampleFramework.release.xcconfig"; sourceTree = "<group>"; };
 		AF5D6E3CC7B8ABF612966884 /* Pods-ExampleFrameworksTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleFrameworksTests.release.xcconfig"; path = "Target Support Files/Pods-ExampleFrameworksTests/Pods-ExampleFrameworksTests.release.xcconfig"; sourceTree = "<group>"; };
-		B6061D8ED9A72EB783A5BE9C /* libPods-ExampleLibs.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ExampleLibs.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		B49326E490E27FCBFA53C5C5 /* libPods-ExampleLibs.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-ExampleLibs.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		B7DBDAD4BB5D3C0327C4F6F7 /* Pods-Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example.debug.xcconfig"; path = "Target Support Files/Pods-Example/Pods-Example.debug.xcconfig"; sourceTree = "<group>"; };
-		BBBA514B6EECE5FB85087400 /* Pods-ExampleLibs.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleLibs.debug.xcconfig"; path = "Target Support Files/Pods-ExampleLibs/Pods-ExampleLibs.debug.xcconfig"; sourceTree = "<group>"; };
-		DB5C1C471C82BE5896935A6A /* Pods-ExampleLibsTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ExampleLibsTests.release.xcconfig"; path = "Target Support Files/Pods-ExampleLibsTests/Pods-ExampleLibsTests.release.xcconfig"; sourceTree = "<group>"; };
 		FCDED70EA50909DB17983904 /* Pods-Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example.release.xcconfig"; path = "Target Support Files/Pods-Example/Pods-Example.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -90,7 +90,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3C4BF03E4A81DE4E6DACC02D /* libPods-ExampleLibs.a in Frameworks */,
+				6A0E6942E3615F37A7C688C4 /* libPods-ExampleLibs.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -98,7 +98,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				04E2710AA358CF6DAD3FA767 /* libPods-ExampleLibsTests.a in Frameworks */,
+				9154D06A9791719D0FF9048C /* libPods-ExampleLibsTests.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -109,10 +109,10 @@
 			isa = PBXGroup;
 			children = (
 				3E07C42579D503D6CBF83C1E /* Pods_Example_ExampleUITests.framework */,
-				B6061D8ED9A72EB783A5BE9C /* libPods-ExampleLibs.a */,
-				144482165AB3009C611A221F /* libPods-ExampleLibsTests.a */,
 				46F83992F7EC25B3096BE7B0 /* Pods_ExampleFrameworks.framework */,
 				9DCED2581A63972952C5F2D0 /* Pods_ExampleFrameworksTests.framework */,
+				B49326E490E27FCBFA53C5C5 /* libPods-ExampleLibs.a */,
+				2FDE4428905573DC827934C6 /* libPods-ExampleLibsTests.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -126,10 +126,6 @@
 				190B134C89F814DE7FA304A7 /* Pods-Example-ExampleUITests.release.xcconfig */,
 				A880AD8271321C709AF97527 /* Pods-ExampleTests.debug.xcconfig */,
 				2FDF6380BEBD68849DCD6B9E /* Pods-ExampleTests.release.xcconfig */,
-				BBBA514B6EECE5FB85087400 /* Pods-ExampleLibs.debug.xcconfig */,
-				48C3D39CC5C27E9B13479331 /* Pods-ExampleLibs.release.xcconfig */,
-				6EE0FC5DD11F25E0210F3143 /* Pods-ExampleLibsTests.debug.xcconfig */,
-				DB5C1C471C82BE5896935A6A /* Pods-ExampleLibsTests.release.xcconfig */,
 				0A4FB7241AE3AEE226DA99EC /* Pods-ExampleFramework.debug.xcconfig */,
 				A9BA1130682EAD2A4CC8DFD7 /* Pods-ExampleFramework.release.xcconfig */,
 				969D03428C0B24E46DC48E68 /* Pods-ExampleFrameworkTests.debug.xcconfig */,
@@ -138,6 +134,10 @@
 				79D74EAF77CA9BBDE5F3EBDB /* Pods-ExampleFrameworks.release.xcconfig */,
 				0B9895EA97AC5C385ADE412B /* Pods-ExampleFrameworksTests.debug.xcconfig */,
 				AF5D6E3CC7B8ABF612966884 /* Pods-ExampleFrameworksTests.release.xcconfig */,
+				A6A53AB767CB3288ECC596F5 /* Pods-ExampleLibs.debug.xcconfig */,
+				8EF2FE1D5E34F824D8DF7AA8 /* Pods-ExampleLibs.release.xcconfig */,
+				191DDE0D6BA6BE48040F162F /* Pods-ExampleLibsTests.debug.xcconfig */,
+				0EC70F0D1DE9F9E451734728 /* Pods-ExampleLibsTests.release.xcconfig */,
 			);
 			name = Pods;
 			path = ../Pods;
@@ -228,11 +228,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 2322FDE02AD468EB00F56303 /* Build configuration list for PBXNativeTarget "ExampleLibs" */;
 			buildPhases = (
-				2322FDD72AD468EB00F56303 /* [CP] Check Pods Manifest.lock */,
+				0C9F34F09DC1AC6A393F1E76 /* [CP] Check Pods Manifest.lock */,
 				2322FDD82AD468EB00F56303 /* Sources */,
 				2322FDDB2AD468EB00F56303 /* Frameworks */,
 				2322FDDD2AD468EB00F56303 /* Resources */,
-				2322FDDE2AD468EB00F56303 /* [CP] Copy Pods Resources */,
+				4C025B27F19FCAD123289A39 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -247,7 +247,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 2322FDEE2AD4696D00F56303 /* Build configuration list for PBXNativeTarget "ExampleLibsTests" */;
 			buildPhases = (
-				2322FDE72AD4696D00F56303 /* [CP] Check Pods Manifest.lock */,
+				AD30EF68D76044540A7F80D8 /* [CP] Check Pods Manifest.lock */,
 				2322FDE82AD4696D00F56303 /* Sources */,
 				2322FDEA2AD4696D00F56303 /* Frameworks */,
 				2322FDEC2AD4696D00F56303 /* Resources */,
@@ -337,7 +337,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		2322FDD72AD468EB00F56303 /* [CP] Check Pods Manifest.lock */ = {
+		0C9F34F09DC1AC6A393F1E76 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -359,45 +359,6 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		2322FDDE2AD468EB00F56303 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-ExampleLibs/Pods-ExampleLibs-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-ExampleLibs/Pods-ExampleLibs-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ExampleLibs/Pods-ExampleLibs-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		2322FDE72AD4696D00F56303 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-ExampleLibsTests-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
 		361990F2F2C015EF1701DC09 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -413,6 +374,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ExampleFrameworks/Pods-ExampleFrameworks-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		4C025B27F19FCAD123289A39 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-ExampleLibs/Pods-ExampleLibs-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-ExampleLibs/Pods-ExampleLibs-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-ExampleLibs/Pods-ExampleLibs-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		9FE67ADA4DDC9B3DCE39540B /* [CP] Check Pods Manifest.lock */ = {
@@ -453,6 +431,28 @@
 			);
 			outputPaths = (
 				"$(DERIVED_FILE_DIR)/Pods-ExampleFrameworks-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		AD30EF68D76044540A7F80D8 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-ExampleLibsTests-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -737,7 +737,7 @@
 		};
 		2322FDE12AD468EB00F56303 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BBBA514B6EECE5FB85087400 /* Pods-ExampleLibs.debug.xcconfig */;
+			baseConfigurationReference = A6A53AB767CB3288ECC596F5 /* Pods-ExampleLibs.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -765,7 +765,7 @@
 		};
 		2322FDE22AD468EB00F56303 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 48C3D39CC5C27E9B13479331 /* Pods-ExampleLibs.release.xcconfig */;
+			baseConfigurationReference = 8EF2FE1D5E34F824D8DF7AA8 /* Pods-ExampleLibs.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -793,7 +793,7 @@
 		};
 		2322FDEF2AD4696D00F56303 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 6EE0FC5DD11F25E0210F3143 /* Pods-ExampleLibsTests.debug.xcconfig */;
+			baseConfigurationReference = 191DDE0D6BA6BE48040F162F /* Pods-ExampleLibsTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -811,7 +811,7 @@
 		};
 		2322FDF02AD4696D00F56303 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = DB5C1C471C82BE5896935A6A /* Pods-ExampleLibsTests.release.xcconfig */;
+			baseConfigurationReference = 0EC70F0D1DE9F9E451734728 /* Pods-ExampleLibsTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;

--- a/Example/LocalPods/LocalLibraryPod.podspec
+++ b/Example/LocalPods/LocalLibraryPod.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |s|
+    s.name     = 'LocalLibraryPod'
+    s.version  = '1.0.0'
+    s.summary  = 'LocalLibraryPod'
+    s.homepage = "none"
+    s.author   = "Khorkov Vyacheslav"
+    s.source   = { :path => "*" }
+
+    s.ios.deployment_target = '16.0'
+    s.static_framework = true
+    s.prefix_header_file = false
+    s.source_files = "#{s.name}/Sources/**/*.swift"
+end

--- a/Example/LocalPods/LocalLibraryPod/Sources/DummySource.swift
+++ b/Example/LocalPods/LocalLibraryPod/Sources/DummySource.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+public final class DummySource {
+    public init() {}
+
+    public func load() {
+        print("mofucka")
+    }
+}
+
+import Foundation
+import SwiftUI
+
+public extension View {
+
+    func sizeReader(to binding: Binding<CGSize>) -> some View {
+        onGeometryChange(for: CGSize.self) { proxy in
+            proxy.size
+        } action: { (newValue: CGSize) in
+            binding.wrappedValue = newValue
+        }
+    }
+
+    func heightReader(to binding: Binding<CGFloat>) -> some View {
+        onGeometryChange(for: CGFloat.self) { proxy in
+            proxy.size.height
+        } action: { newValue in
+            binding.wrappedValue = newValue
+        }
+    }
+
+    func widthReader(to binding: Binding<CGFloat>) -> some View {
+        onGeometryChange(for: CGFloat.self) { proxy in
+            proxy.size.width
+        } action: { newValue in
+            binding.wrappedValue = newValue
+        }
+    }
+
+    func sizeListener(adding insets: EdgeInsets = .init()) -> some View {
+        modifier(SizeListenerModifier(insets: insets))
+    }
+}
+
+private struct SizeListenerModifier: ViewModifier {
+
+    let insets: EdgeInsets
+
+    @Environment(\.contentSizeListener) private var contentSizeListener
+    @State private var size: CGSize = .zero
+
+    func body(content: Content) -> some View {
+        if let contentSizeListener {
+            content
+                .sizeReader(to: .init(get: { .zero }, set: { size = $0 }))
+                .onChange(of: fullSize) {
+                    contentSizeListener($0)
+                }
+        } else {
+            content
+        }
+    }
+
+    var fullSize: CGSize {
+        CGSize(
+            width: size.width + insets.leading + insets.trailing,
+            height: size.height + insets.top + insets.bottom
+        )
+    }
+}
+
+public extension EnvironmentValues {
+
+    @Entry var contentSizeListener: ContentSizeListener? = nil
+}
+
+public typealias ContentSizeListener = @MainActor @Sendable (CGSize) -> Void

--- a/Example/LocalPods/LocalPod.podspec
+++ b/Example/LocalPods/LocalPod.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
     ]
   }
   s.dependency 'Moya/Core'
-
+  s.dependency 'LocalLibraryPod'
   s.test_spec 'Tests' do |ts|
     ts.source_files = "#{s.name}/Tests/**/*.swift"
     ts.resources = "#{s.name}/Tests/**/*.{json,xcassets}"

--- a/Example/LocalPods/LocalPod/Sources/TheView.swift
+++ b/Example/LocalPods/LocalPod/Sources/TheView.swift
@@ -1,0 +1,19 @@
+import LocalLibraryPod
+import SwiftUI
+
+public struct SomeSizeReaderView: View {
+
+    @State var size: CGSize = .zero
+
+    public var body: some View {
+        HStack {
+            Text("Hi")
+            Text("Hey")
+        }
+        .sizeReader(to: $size)
+    }
+}
+
+#Preview {
+    SomeSizeReaderView()
+}

--- a/Example/Podfile
+++ b/Example/Podfile
@@ -12,6 +12,7 @@ target 'ExampleFrameworks' do
   pod 'Moya/Core'
   pod 'Kingfisher'
   pod 'LocalPod', :path => 'LocalPods', :testspecs => ['Tests', 'ResourceBundleTests']
+  pod 'LocalLibraryPod', :path => 'LocalPods'
 
   target 'ExampleFrameworksTests' do
     inherit! :search_paths
@@ -41,7 +42,7 @@ post_install do |installer|
           config.build_settings['GCC_TREAT_WARNINGS_AS_ERRORS'] = 'YES'
         end
       end
-      
+
       target.build_configurations.each do |config|
         config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '16.0'
       end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -2,11 +2,15 @@ PODS:
   - Alamofire (5.8.0)
   - "Keyboard+LayoutGuide (1.6.0)"
   - Kingfisher (7.9.1)
+  - LocalLibraryPod (1.0.0)
   - LocalPod (1.0.0):
+    - LocalLibraryPod
     - Moya/Core
   - LocalPod/ResourceBundleTests (1.0.0):
+    - LocalLibraryPod
     - Moya/Core
   - LocalPod/Tests (1.0.0):
+    - LocalLibraryPod
     - Moya/Core
   - Moya/Core (15.0.0):
     - Alamofire (~> 5.0)
@@ -15,6 +19,7 @@ PODS:
 DEPENDENCIES:
   - "Keyboard+LayoutGuide"
   - Kingfisher
+  - LocalLibraryPod (from `LocalPods`)
   - LocalPod (from `LocalPods`)
   - LocalPod/ResourceBundleTests (from `LocalPods`)
   - LocalPod/Tests (from `LocalPods`)
@@ -30,6 +35,8 @@ SPEC REPOS:
     - SnapKit
 
 EXTERNAL SOURCES:
+  LocalLibraryPod:
+    :path: LocalPods
   LocalPod:
     :path: LocalPods
 
@@ -37,10 +44,11 @@ SPEC CHECKSUMS:
   Alamofire: 0e92e751b3e9e66d7982db43919d01f313b8eb91
   "Keyboard+LayoutGuide": db44b1764e2bb5d9824cc9cea9d9006cd4442045
   Kingfisher: 1d14e9f59cbe19389f591c929000332bf70efd32
-  LocalPod: 98c9e510a9ffb889839862aafcde67a1bd2e503f
+  LocalLibraryPod: f0954a6b1943bbf3dad9d80779f29d6a028c2b41
+  LocalPod: 389e2130d738357e4f16b6e0215db69dab582ec3
   Moya: 138f0573e53411fb3dc17016add0b748dfbd78ee
   SnapKit: e01d52ebb8ddbc333eefe2132acf85c8227d9c25
 
-PODFILE CHECKSUM: 931db3cc9bfaa8e99f4ecd1c4ad6b31af8ac55e8
+PODFILE CHECKSUM: 2ff048a5312d2ac175508870b96a8dfa7565bff0
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.16.2


### PR DESCRIPTION
Here is a reproduction of an issue we have on a project:

<details>
<summary>Rugby output</summary>

```
❯ ./../Release/rugby --prebuild --targets Pods-ExampleFrameworks
⚑ Cache --prebuild --targets Pods-ExampleFrameworks
  ⚑ Prebuild
    ✓ CLT: Xcode 16.3
    ✓ Reading Project
    ✓ Finding Build Targets
    ✓ Backuping
    ✓ Removing Build Phases
    ✓ Skip
  ✓ Prebuild
  ⚑ Build
    ✓ CLT: Xcode 16.3
    ✓ Reading Project
    ✓ Finding Build Targets
    ✓ Backuping
    ✓ Checking Binaries Storage
    ✓ Patching Libraries
    ✓ Hashing Targets
    ✓ Finding Binaries
    ✓ Creating Build Target
    ✓ Saving Project
    ⚑ Build Debug: sim-arm64 (8)
      ⚑ Beautifying Log
        ✓ Cleaning Up
⛔️ Error: Xcodebuild failed.
 ✖ lstat(.rugby/build/Pods.build/Debug-iphonesimulator/LocalPod-framework.build/Objects-normal/arm64/LocalPod.abi.json): No such file or directory (2) (in target 'LocalPod-framework' from project 'Pods')
 ✖ lstat(.rugby/build/Pods.build/Debug-iphonesimulator/LocalPod-framework.build/Objects-normal/arm64/LocalPod.swiftmodule): No such file or directory (2) (in target 'LocalPod-framework' from project 'Pods')
 ✖ lstat(.rugby/build/Pods.build/Debug-iphonesimulator/LocalPod-framework.build/Objects-normal/arm64/LocalPod.swiftdoc): No such file or directory (2) (in target 'LocalPod-framework' from project 'Pods')
 ✖ lstat(.rugby/build/Pods.build/Debug-iphonesimulator/LocalPod-framework.build/Objects-normal/arm64/LocalPod.swiftsourceinfo): No such file or directory (2) (in target 'LocalPod-framework' from project 'Pods')
🚑 More information in build logs:
[Beautified] cat ~/.rugby/logs/11.04.2025T08.35.23/build.log
[Raw] open ~/.rugby/logs/11.04.2025T08.35.23/rawBuild.log
```

</details>

<details>
<summary>Part of build log</summary>

```
/Applications/Xcode-16.3.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift-frontend -frontend -c /Users/agp1/Developer/Rugby/Example/LocalPods/LocalPod/Sources/Bundle+Resources.swift /Users/agp1/Developer/Rugby/Example/LocalPods/LocalPod/Sources/DummySource.swift /Users/agp1/Developer/Rugby/Example/LocalPods/LocalPod/Sources/TheView.swift -supplementary-output-file-map /Users/agp1/Developer/Rugby/Example/.rugby/build/Pods.build/Debug-iphonesimulator/LocalPod-framework.build/Objects-normal/arm64/supplementaryOutputs-5 -target arm64-apple-ios16.0-simulator -Xllvm -aarch64-use-tbi -enable-objc-interop -sdk /Applications/Xcode-16.3.0.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator18.4.sdk -I /Users/agp1/Developer/Rugby/Example/.rugby/build/Debug-iphonesimulator/LocalPod-framework -F /Users/agp1/Developer/Rugby/Example/.rugby/build/Debug-iphonesimulator/LocalPod-framework -F /Users/agp1/Developer/Rugby/Example/.rugby/build/Debug-iphonesimulator/Alamofire-framework -F /Users/agp1/Developer/Rugby/Example/.rugby/build/Debug-iphonesimulator/LocalLibraryPod-framework -F /Users/agp1/Developer/Rugby/Example/.rugby/build/Debug-iphonesimulator/Moya-framework -no-color-diagnostics -enable-testing -g -debug-info-format\=dwarf -dwarf-version\=4 -import-underlying-module -warnings-as-errors -warnings-as-errors -swift-version 5 -enforce-exclusivity\=checked -Onone -D DEBUG -D COCOAPODS -serialize-debugging-options -const-gather-protocols-file /Users/agp1/Developer/Rugby/Example/.rugby/build/Pods.build/Debug-iphonesimulator/LocalPod-framework.build/Objects-normal/arm64/LocalPod-framework_const_extract_protocols.json -enable-experimental-feature DebugDescriptionMacro -enable-bare-slash-regex -empty-abi-descriptor -validate-clang-modules-once -clang-build-session-file /var/folders/8n/h4qvsvq569n0npb_y9fpxblh0000gn/C/org.llvm.clang/ModuleCache.noindex/Session.modulevalidation -Xcc -working-directory -Xcc /Users/agp1/Developer/Rugby/Example/Pods -resource-dir /Applications/Xcode-16.3.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift -enable-anonymous-context-mangled-names -file-compilation-dir /Users/agp1/Developer/Rugby/Example/Pods -Xcc -ivfsstatcache -Xcc /var/folders/8n/h4qvsvq569n0npb_y9fpxblh0000gn/C/com.apple.DeveloperTools/16.3-16E140/Xcode/SDKStatCaches.noindex/iphonesimulator18.4-22E235-43e5fd89280df366c77438703b8fa853.sdkstatcache -Xcc -I/Users/agp1/Developer/Rugby/Example/.rugby/build/Pods.build/Debug-iphonesimulator/LocalPod-framework.build/swift-overrides.hmap -Xcc -iquote -Xcc /Users/agp1/Developer/Rugby/Example/.rugby/build/Pods.build/Debug-iphonesimulator/LocalPod-framework.build/LocalPod-generated-files.hmap -Xcc -I/Users/agp1/Developer/Rugby/Example/.rugby/build/Pods.build/Debug-iphonesimulator/LocalPod-framework.build/LocalPod-own-target-headers.hmap -Xcc -I/Users/agp1/Developer/Rugby/Example/.rugby/build/Pods.build/Debug-iphonesimulator/LocalPod-framework.build/LocalPod-all-non-framework-target-headers.hmap -Xcc -ivfsoverlay -Xcc /Users/agp1/Developer/Rugby/Example/.rugby/build/Pods.build/Debug-iphonesimulator/Pods-bfdfe7dc352907fc980b868725387e98-VFS-iphonesimulator/all-product-headers.yaml -Xcc -iquote -Xcc /Users/agp1/Developer/Rugby/Example/.rugby/build/Pods.build/Debug-iphonesimulator/LocalPod-framework.build/LocalPod-project-headers.hmap -Xcc -I/Users/agp1/Developer/Rugby/Example/.rugby/build/Debug-iphonesimulator/LocalPod-framework/include -Xcc -I/Users/agp1/Developer/Rugby/Example/.rugby/build/Pods.build/Debug-iphonesimulator/LocalPod-framework.build/DerivedSources-normal/arm64 -Xcc -I/Users/agp1/Developer/Rugby/Example/.rugby/build/Pods.build/Debug-iphonesimulator/LocalPod-framework.build/DerivedSources/arm64 -Xcc -I/Users/agp1/Developer/Rugby/Example/.rugby/build/Pods.build/Debug-iphonesimulator/LocalPod-framework.build/DerivedSources -Xcc -DPOD_CONFIGURATION_DEBUG\=1 -Xcc -DDEBUG\=1 -Xcc -DCOCOAPODS\=1 -Xcc -ivfsoverlay -Xcc /Users/agp1/Developer/Rugby/Example/.rugby/build/Pods.build/Debug-iphonesimulator/LocalPod-framework.build/unextended-module-overlay.yaml -module-name LocalPod -frontend-parseable-output -disable-clang-spi -target-sdk-version 18.4 -target-sdk-name iphonesimulator18.4 -external-plugin-path /Applications/Xcode-16.3.0.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/usr/lib/swift/host/plugins\#/Applications/Xcode-16.3.0.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/usr/bin/swift-plugin-server -external-plugin-path /Applications/Xcode-16.3.0.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/usr/local/lib/swift/host/plugins\#/Applications/Xcode-16.3.0.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/usr/bin/swift-plugin-server -in-process-plugin-server-path /Applications/Xcode-16.3.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/host/libSwiftInProcPluginServer.dylib -plugin-path /Applications/Xcode-16.3.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/host/plugins -plugin-path /Applications/Xcode-16.3.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/local/lib/swift/host/plugins -num-threads 14 -o /Users/agp1/Developer/Rugby/Example/.rugby/build/Pods.build/Debug-iphonesimulator/LocalPod-framework.build/Objects-normal/arm64/Bundle+Resources.o -o /Users/agp1/Developer/Rugby/Example/.rugby/build/Pods.build/Debug-iphonesimulator/LocalPod-framework.build/Objects-normal/arm64/DummySource.o -o /Users/agp1/Developer/Rugby/Example/.rugby/build/Pods.build/Debug-iphonesimulator/LocalPod-framework.build/Objects-normal/arm64/TheView.o -index-unit-output-path /Pods.build/Debug-iphonesimulator/LocalPod-framework.build/Objects-normal/arm64/Bundle+Resources.o -index-unit-output-path /Pods.build/Debug-iphonesimulator/LocalPod-framework.build/Objects-normal/arm64/DummySource.o -index-unit-output-path /Pods.build/Debug-iphonesimulator/LocalPod-framework.build/Objects-normal/arm64/TheView.o
Command SwiftCompile failed with a nonzero exit code
Please submit a bug report (https://swift.org/contributing/#reporting-bugs) and include the crash backtrace.
Stack dump:
0.	Program arguments: /Applications/Xcode-16.3.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swift-frontend -frontend -c /Users/agp1/Developer/Rugby/Example/LocalPods/LocalPod/Sources/Bundle+Resources.swift /Users/agp1/Developer/Rugby/Example/LocalPods/LocalPod/Sources/DummySource.swift /Users/agp1/Developer/Rugby/Example/LocalPods/LocalPod/Sources/TheView.swift -supplementary-output-file-map /Users/agp1/Developer/Rugby/Example/.rugby/build/Pods.build/Debug-iphonesimulator/LocalPod-framework.build/Objects-normal/arm64/supplementaryOutputs-5 -target arm64-apple-ios16.0-simulator -Xllvm -aarch64-use-tbi -enable-objc-interop -sdk /Applications/Xcode-16.3.0.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator18.4.sdk -I /Users/agp1/Developer/Rugby/Example/.rugby/build/Debug-iphonesimulator/LocalPod-framework -F /Users/agp1/Developer/Rugby/Example/.rugby/build/Debug-iphonesimulator/LocalPod-framework -F /Users/agp1/Developer/Rugby/Example/.rugby/build/Debug-iphonesimulator/Alamofire-framework -F /Users/agp1/Developer/Rugby/Example/.rugby/build/Debug-iphonesimulator/LocalLibraryPod-framework -F /Users/agp1/Developer/Rugby/Example/.rugby/build/Debug-iphonesimulator/Moya-framework -no-color-diagnostics -enable-testing -g -debug-info-format=dwarf -dwarf-version=4 -import-underlying-module -warnings-as-errors -warnings-as-errors -swift-version 5 -enforce-exclusivity=checked -Onone -D DEBUG -D COCOAPODS -serialize-debugging-options -const-gather-protocols-file /Users/agp1/Developer/Rugby/Example/.rugby/build/Pods.build/Debug-iphonesimulator/LocalPod-framework.build/Objects-normal/arm64/LocalPod-framework_const_extract_protocols.json -enable-experimental-feature DebugDescriptionMacro -enable-bare-slash-regex -empty-abi-descriptor -validate-clang-modules-once -clang-build-session-file /var/folders/8n/h4qvsvq569n0npb_y9fpxblh0000gn/C/org.llvm.clang/ModuleCache.noindex/Session.modulevalidation -Xcc -working-directory -Xcc /Users/agp1/Developer/Rugby/Example/Pods -resource-dir /Applications/Xcode-16.3.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift -enable-anonymous-context-mangled-names -file-compilation-dir /Users/agp1/Developer/Rugby/Example/Pods -Xcc -ivfsstatcache -Xcc /var/folders/8n/h4qvsvq569n0npb_y9fpxblh0000gn/C/com.apple.DeveloperTools/16.3-16E140/Xcode/SDKStatCaches.noindex/iphonesimulator18.4-22E235-43e5fd89280df366c77438703b8fa853.sdkstatcache -Xcc -I/Users/agp1/Developer/Rugby/Example/.rugby/build/Pods.build/Debug-iphonesimulator/LocalPod-framework.build/swift-overrides.hmap -Xcc -iquote -Xcc /Users/agp1/Developer/Rugby/Example/.rugby/build/Pods.build/Debug-iphonesimulator/LocalPod-framework.build/LocalPod-generated-files.hmap -Xcc -I/Users/agp1/Developer/Rugby/Example/.rugby/build/Pods.build/Debug-iphonesimulator/LocalPod-framework.build/LocalPod-own-target-headers.hmap -Xcc -I/Users/agp1/Developer/Rugby/Example/.rugby/build/Pods.build/Debug-iphonesimulator/LocalPod-framework.build/LocalPod-all-non-framework-target-headers.hmap -Xcc -ivfsoverlay -Xcc /Users/agp1/Developer/Rugby/Example/.rugby/build/Pods.build/Debug-iphonesimulator/Pods-bfdfe7dc352907fc980b868725387e98-VFS-iphonesimulator/all-product-headers.yaml -Xcc -iquote -Xcc /Users/agp1/Developer/Rugby/Example/.rugby/build/Pods.build/Debug-iphonesimulator/LocalPod-framework.build/LocalPod-project-headers.hmap -Xcc -I/Users/agp1/Developer/Rugby/Example/.rugby/build/Debug-iphonesimulator/LocalPod-framework/include -Xcc -I/Users/agp1/Developer/Rugby/Example/.rugby/build/Pods.build/Debug-iphonesimulator/LocalPod-framework.build/DerivedSources-normal/arm64 -Xcc -I/Users/agp1/Developer/Rugby/Example/.rugby/build/Pods.build/Debug-iphonesimulator/LocalPod-framework.build/DerivedSources/arm64 -Xcc -I/Users/agp1/Developer/Rugby/Example/.rugby/build/Pods.build/Debug-iphonesimulator/LocalPod-framework.build/DerivedSources -Xcc -DPOD_CONFIGURATION_DEBUG=1 -Xcc -DDEBUG=1 -Xcc -DCOCOAPODS=1 -Xcc -ivfsoverlay -Xcc /Users/agp1/Developer/Rugby/Example/.rugby/build/Pods.build/Debug-iphonesimulator/LocalPod-framework.build/unextended-module-overlay.yaml -module-name LocalPod -frontend-parseable-output -disable-clang-spi -target-sdk-version 18.4 -target-sdk-name iphonesimulator18.4 -external-plugin-path /Applications/Xcode-16.3.0.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/usr/lib/swift/host/plugins#/Applications/Xcode-16.3.0.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/usr/bin/swift-plugin-server -external-plugin-path /Applications/Xcode-16.3.0.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/usr/local/lib/swift/host/plugins#/Applications/Xcode-16.3.0.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/usr/bin/swift-plugin-server -in-process-plugin-server-path /Applications/Xcode-16.3.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/host/libSwiftInProcPluginServer.dylib -plugin-path /Applications/Xcode-16.3.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/host/plugins -plugin-path /Applications/Xcode-16.3.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/local/lib/swift/host/plugins -num-threads 14 -o /Users/agp1/Developer/Rugby/Example/.rugby/build/Pods.build/Debug-iphonesimulator/LocalPod-framework.build/Objects-normal/arm64/Bundle+Resources.o -o /Users/agp1/Developer/Rugby/Example/.rugby/build/Pods.build/Debug-iphonesimulator/LocalPod-framework.build/Objects-normal/arm64/DummySource.o -o /Users/agp1/Developer/Rugby/Example/.rugby/build/Pods.build/Debug-iphonesimulator/LocalPod-framework.build/Objects-normal/arm64/TheView.o -index-unit-output-path /Pods.build/Debug-iphonesimulator/LocalPod-framework.build/Objects-normal/arm64/Bundle+Resources.o -index-unit-output-path /Pods.build/Debug-iphonesimulator/LocalPod-framework.build/Objects-normal/arm64/DummySource.o -index-unit-output-path /Pods.build/Debug-iphonesimulator/LocalPod-framework.build/Objects-normal/arm64/TheView.o
1.	Apple Swift version 6.1 (swiftlang-6.1.0.110.21 clang-1700.0.13.3)
2.	Compiling with effective version 5.10
3.	While evaluating request TypeCheckSourceFileRequest(source_file "/Users/agp1/Developer/Rugby/Example/LocalPods/LocalPod/Sources/TheView.swift")
4.	While evaluating request TypeCheckFunctionBodyRequest(LocalPod.(file).SomeSizeReaderView._@/Users/agp1/Developer/Rugby/Example/LocalPods/LocalPod/Sources/TheView.swift:8:32)
5.	While evaluating request QualifiedLookupRequest(0x118ac5f18 AbstractFunctionDecl name=_ : (SomeSizeReaderView) -> () -> some View, {SwiftUICore.(file).HStack}, 'sizeReader', { NL_ProtocolMembers, NL_IgnoreMissingImports })
6.	While evaluating request DirectLookupRequest(directly looking up 'sizeReader' on SwiftUICore.(file).View with options {  })
7.	While loading members for extension of View (in module 'LocalLibraryPod')
8.	While deserializing 'sizeReader' (FuncDecl @ 168090) in 'LocalLibraryPod'
9.	    ...decl is named 'sizeReader(to:)'
10.	While deserializing '_' (OpaqueTypeDecl @ 166555) in 'LocalLibraryPod'
11.	While cross-referencing conformance for 'CGSize' (at /Applications/Xcode-16.3.0.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator18.4.sdk/System/Library/Frameworks/CoreFoundation.framework/Headers/CFCGTypes.h:58:8)
12.	While ... to 'Sendable' (in module 'Swift')
13.	If you're seeing a crash here, check that your SDK and dependencies are at least as new as the versions used to build module 'LocalLibraryPod', builder version '6.1(5.10)/Apple Swift version 6.1 (swiftlang-6.1.0.110.21 clang-1700.0.13.3)', built from source against SDK 22E235, non-resilient, loaded from '/Users/agp1/Developer/Rugby/Example/.rugby/build/Debug-iphonesimulator/LocalLibraryPod-framework/LocalLibraryPod.framework/Modules/LocalLibraryPod.swiftmodule/arm64-apple-ios-simulator.swiftmodule'
Stack dump without symbol names (ensure you have llvm-symbolizer in your PATH or set the environment var `LLVM_SYMBOLIZER_PATH` to point to it):
0  swift-frontend           0x00000001072f2c28 llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) + 56
1  swift-frontend           0x00000001072f0a60 llvm::sys::RunSignalHandlers() + 112
2  swift-frontend           0x00000001072f3264 SignalHandler(int) + 360
3  libsystem_platform.dylib 0x0000000192e62de4 _sigtramp + 56
4  libsystem_pthread.dylib  0x0000000192e2bf70 pthread_kill + 288
5  libsystem_c.dylib        0x0000000192d38908 abort + 128
6  swift-frontend           0x0000000101896e90 swift::ProtocolConformanceDeserializer::readNormalProtocolConformanceXRef(llvm::ArrayRef<unsigned long long>) + 952
7  swift-frontend           0x00000001018986c0 swift::ModuleFile::getConformanceChecked(llvm::PointerEmbeddedInt<unsigned int, 31>) + 1932
8  swift-frontend           0x0000000101897430 swift::ModuleFile::getSubstitutionMapChecked(llvm::PointerEmbeddedInt<unsigned int, 31>) + 908
9  swift-frontend           0x00000001018b5a58 swift::serialization::decls_block::detail::TypeRecordDispatch<(swift::serialization::decls_block::detail::TypeRecords)12>::deserialize(swift::ModuleFile&, llvm::SmallVectorImpl<unsigned long long>&, llvm::StringRef) + 176
10 swift-frontend           0x0000000101895844 swift::ModuleFile::getTypeChecked(llvm::PointerEmbeddedInt<unsigned int, 31>) + 1304
11 swift-frontend           0x00000001018974a8 swift::ModuleFile::getSubstitutionMapChecked(llvm::PointerEmbeddedInt<unsigned int, 31>) + 1028
12 swift-frontend           0x00000001018acad8 swift::DeclDeserializer::deserializeOpaqueType(llvm::ArrayRef<unsigned long long>, llvm::StringRef) + 608
13 swift-frontend           0x0000000101894218 swift::ModuleFile::getDeclChecked(llvm::PointerEmbeddedInt<unsigned int, 31>, llvm::function_ref<bool (swift::DeclAttributes)>) + 2748
14 swift-frontend           0x00000001018b59e4 swift::serialization::decls_block::detail::TypeRecordDispatch<(swift::serialization::decls_block::detail::TypeRecords)12>::deserialize(swift::ModuleFile&, llvm::SmallVectorImpl<unsigned long long>&, llvm::StringRef) + 60
15 swift-frontend           0x0000000101895844 swift::ModuleFile::getTypeChecked(llvm::PointerEmbeddedInt<unsigned int, 31>) + 1304
16 swift-frontend           0x00000001018c3ff4 swift::DeclDeserializer::deserializeAnyFunc(llvm::ArrayRef<unsigned long long>, llvm::StringRef, bool) + 2192
17 swift-frontend           0x0000000101894354 swift::ModuleFile::getDeclChecked(llvm::PointerEmbeddedInt<unsigned int, 31>, llvm::function_ref<bool (swift::DeclAttributes)>) + 3064
18 swift-frontend           0x00000001018f60dc swift::ModuleFile::loadNamedMembers(swift::IterableDeclContext const*, swift::DeclBaseName, unsigned long long) + 1644
19 swift-frontend           0x0000000102b36298 populateLookupTableEntryFromLazyIDCLoader(swift::ASTContext&, swift::MemberLookupTable&, swift::DeclBaseName, swift::IterableDeclContext*) + 108
20 swift-frontend           0x0000000102b340b0 swift::DirectLookupRequest::evaluate(swift::Evaluator&, swift::DirectLookupDescriptor) const + 588
21 swift-frontend           0x0000000102b521fc swift::SimpleRequest<swift::DirectLookupRequest, llvm::TinyPtrVector<swift::ValueDecl*> (swift::DirectLookupDescriptor), (swift::RequestFlags)33>::evaluateRequest(swift::DirectLookupRequest const&, swift::Evaluator&) + 36
22 swift-frontend           0x0000000102b4586c swift::DirectLookupRequest::OutputType swift::Evaluator::getResultUncached<swift::DirectLookupRequest, swift::DirectLookupRequest::OutputType swift::evaluateOrDefault<swift::DirectLookupRequest>(swift::Evaluator&, swift::DirectLookupRequest, swift::DirectLookupRequest::OutputType)::'lambda'()>(swift::DirectLookupRequest const&, swift::DirectLookupRequest::OutputType swift::evaluateOrDefault<swift::DirectLookupRequest>(swift::Evaluator&, swift::DirectLookupRequest, swift::DirectLookupRequest::OutputType)::'lambda'()) + 548
23 swift-frontend           0x0000000102b33e20 swift::DirectLookupRequest::OutputType swift::evaluateOrDefault<swift::DirectLookupRequest>(swift::Evaluator&, swift::DirectLookupRequest, swift::DirectLookupRequest::OutputType) + 196
24 swift-frontend           0x0000000102b33d18 swift::NominalTypeDecl::lookupDirect(swift::DeclName, swift::SourceLoc, swift::optionset::OptionSet<swift::NominalTypeDecl::LookupDirectFlags, unsigned int>) + 260
25 swift-frontend           0x0000000102b39290 swift::QualifiedLookupRequest::evaluate(swift::Evaluator&, swift::DeclContext const*, llvm::SmallVector<swift::NominalTypeDecl*, 4u>, swift::DeclNameRef, swift::NLOptions) const + 1328
26 swift-frontend           0x0000000102b523e4 swift::SimpleRequest<swift::QualifiedLookupRequest, llvm::SmallVector<swift::ValueDecl*, 4u> (swift::DeclContext const*, llvm::SmallVector<swift::NominalTypeDecl*, 4u>, swift::DeclNameRef, swift::NLOptions), (swift::RequestFlags)1>::evaluateRequest(swift::QualifiedLookupRequest const&, swift::Evaluator&) + 192
27 swift-frontend           0x0000000102b38958 swift::DeclContext::lookupQualified(llvm::ArrayRef<swift::NominalTypeDecl*>, swift::DeclNameRef, swift::SourceLoc, swift::NLOptions, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 1088
28 swift-frontend           0x0000000102b38008 swift::DeclContext::lookupQualified(swift::Type, swift::DeclNameRef, swift::SourceLoc, swift::NLOptions, llvm::SmallVectorImpl<swift::ValueDecl*>&) const + 464
29 swift-frontend           0x00000001025fd3d4 swift::TypeChecker::lookupMember(swift::DeclContext*, swift::Type, swift::DeclNameRef, swift::SourceLoc, swift::optionset::OptionSet<swift::NameLookupFlags, unsigned int>) + 324
30 swift-frontend           0x00000001023e99b8 swift::constraints::ConstraintSystem::lookupMember(swift::Type, swift::DeclNameRef, swift::SourceLoc) + 372
31 swift-frontend           0x000000010230aee4 swift::constraints::ConstraintSystem::performMemberLookup(swift::constraints::ConstraintKind, swift::DeclNameRef, swift::Type, swift::FunctionRefKind, swift::constraints::ConstraintLocator*, bool) + 3520
32 swift-frontend           0x000000010230e81c swift::constraints::ConstraintSystem::simplifyMemberConstraint(swift::constraints::ConstraintKind, swift::Type, swift::DeclNameRef, swift::Type, swift::DeclContext*, swift::FunctionRefKind, llvm::ArrayRef<swift::constraints::OverloadChoice>, swift::optionset::OptionSet<swift::constraints::ConstraintSystem::TypeMatchFlags, unsigned int>, swift::constraints::ConstraintLocatorBuilder) + 2996
33 swift-frontend           0x00000001022d6294 (anonymous namespace)::ConstraintGenerator::addMemberRefConstraints(swift::Expr*, swift::Expr*, swift::DeclNameRef, swift::FunctionRefKind, llvm::ArrayRef<swift::ValueDecl*>) + 760
34 swift-frontend           0x00000001022ccf44 (anonymous namespace)::ConstraintGenerator::visitUnresolvedDotExpr(swift::UnresolvedDotExpr*) + 584
35 swift-frontend           0x00000001022c76c8 (anonymous namespace)::ConstraintWalker::walkToExprPost(swift::Expr*) + 1584
36 swift-frontend           0x000000010290e854 (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) + 116
37 swift-frontend           0x000000010290bdf0 (anonymous namespace)::Traversal::visit(swift::Expr*) + 84
38 swift-frontend           0x0000000102911c98 (anonymous namespace)::Traversal::visit(swift::ArgumentList*) + 260
39 swift-frontend           0x000000010290e8a4 (anonymous namespace)::Traversal::visitApplyExpr(swift::ApplyExpr*) + 196
40 swift-frontend           0x000000010290bdf0 (anonymous namespace)::Traversal::visit(swift::Expr*) + 84
41 swift-frontend           0x00000001022c114c swift::constraints::ConstraintSystem::generateConstraints(swift::Expr*, swift::DeclContext*) + 216
42 swift-frontend           0x00000001022c084c swift::constraints::ConstraintSystem::generateConstraints(swift::constraints::SyntacticElementTarget&, swift::FreeTypeVariableBinding) + 1812
43 swift-frontend           0x00000001022be1f4 (anonymous namespace)::SyntacticElementConstraintGenerator::visitDecl(swift::Decl*) + 1212
44 swift-frontend           0x00000001022b4434 swift::constraints::ConstraintSystem::simplifySyntacticElementConstraint(swift::ASTNode, swift::constraints::ContextualTypeInfo, bool, swift::optionset::OptionSet<swift::constraints::ConstraintSystem::TypeMatchFlags, unsigned int>, swift::constraints::ConstraintLocatorBuilder) + 888
45 swift-frontend           0x0000000102322d70 swift::constraints::ConstraintSystem::simplifyConstraint(swift::constraints::Constraint const&) + 740
46 swift-frontend           0x000000010233f0b4 swift::constraints::ConjunctionElement::attempt(swift::constraints::ConstraintSystem&) const + 332
47 swift-frontend           0x000000010234c52c swift::constraints::ConjunctionStep::attempt(swift::constraints::ConjunctionElement const&) + 424
48 swift-frontend           0x000000010234e2d4 swift::constraints::BindingStep<swift::constraints::ConjunctionElementProducer>::take(bool) + 976
49 swift-frontend           0x0000000102337de4 swift::constraints::ConstraintSystem::solveImpl(llvm::SmallVectorImpl<swift::constraints::Solution>&) + 624
50 swift-frontend           0x000000010233afd0 swift::constraints::ConstraintSystem::solve(llvm::SmallVectorImpl<swift::constraints::Solution>&, swift::FreeTypeVariableBinding) + 60
51 swift-frontend           0x0000000102254edc swift::TypeChecker::applyResultBuilderBodyTransform(swift::FuncDecl*, swift::Type) + 2168
52 swift-frontend           0x00000001026485ec swift::TypeCheckFunctionBodyRequest::evaluate(swift::Evaluator&, swift::AbstractFunctionDecl*) const + 496
53 swift-frontend           0x0000000102a455ec swift::TypeCheckFunctionBodyRequest::OutputType swift::Evaluator::getResultUncached<swift::TypeCheckFunctionBodyRequest, swift::TypeCheckFunctionBodyRequest::OutputType swift::evaluateOrDefault<swift::TypeCheckFunctionBodyRequest>(swift::Evaluator&, swift::TypeCheckFunctionBodyRequest, swift::TypeCheckFunctionBodyRequest::OutputType)::'lambda'()>(swift::TypeCheckFunctionBodyRequest const&, swift::TypeCheckFunctionBodyRequest::OutputType swift::evaluateOrDefault<swift::TypeCheckFunctionBodyRequest>(swift::Evaluator&, swift::TypeCheckFunctionBodyRequest, swift::TypeCheckFunctionBodyRequest::OutputType)::'lambda'()) + 640
54 swift-frontend           0x00000001029a81a8 swift::AbstractFunctionDecl::getTypecheckedBody() const + 160
55 swift-frontend           0x000000010269a7e0 swift::TypeCheckSourceFileRequest::evaluate(swift::Evaluator&, swift::SourceFile*) const + 912
56 swift-frontend           0x00000001026a0b18 swift::TypeCheckSourceFileRequest::OutputType swift::Evaluator::getResultUncached<swift::TypeCheckSourceFileRequest, swift::TypeCheckSourceFileRequest::OutputType swift::evaluateOrDefault<swift::TypeCheckSourceFileRequest>(swift::Evaluator&, swift::TypeCheckSourceFileRequest, swift::TypeCheckSourceFileRequest::OutputType)::'lambda'()>(swift::TypeCheckSourceFileRequest const&, swift::TypeCheckSourceFileRequest::OutputType swift::evaluateOrDefault<swift::TypeCheckSourceFileRequest>(swift::Evaluator&, swift::TypeCheckSourceFileRequest, swift::TypeCheckSourceFileRequest::OutputType)::'lambda'()) + 624
57 swift-frontend           0x000000010269a434 swift::performTypeChecking(swift::SourceFile&) + 308
58 swift-frontend           0x0000000101504060 swift::CompilerInstance::performSema() + 320
59 swift-frontend           0x0000000101147274 performCompile(swift::CompilerInstance&, int&, swift::FrontendObserver*) + 772
60 swift-frontend           0x0000000101145fd8 swift::performFrontend(llvm::ArrayRef<char const*>, char const*, void*, swift::FrontendObserver*) + 3716
61 swift-frontend           0x00000001010ca0bc swift::mainEntry(int, char const**) + 5428
62 dyld                     0x0000000192aac274 start + 2840
```

</details>



xcbeautify can't even display these new messages, so I have to look into rawBuild.log.

Somehow this code compiles successfully inside Xcode 16.3, but fails if I compile it with Rugby.