### PR TITLE
Fix build on Xcode 16.3

### DIFF
--- a/Example/Tests/cache_tests.sh
+++ b/Example/Tests/cache_tests.sh
@@ -21,7 +21,6 @@ set -o pipefail && env NSUnbufferedIO=YES arch -arm64 xcodebuild test \
   -testPlan ExampleFrameworks \
   -destination "platform=iOS Simulator,name=iPhone 16" \
   COMPILER_INDEX_STORE_ENABLE=NO \
-  SWIFT_COMPILATION_MODE=wholemodule \
   CODE_SIGNING_ALLOWED=NO \
   | xcbeautify
 set -o pipefail && env NSUnbufferedIO=YES arch -arm64 xcodebuild test \
@@ -30,6 +29,5 @@ set -o pipefail && env NSUnbufferedIO=YES arch -arm64 xcodebuild test \
   -testPlan ExampleLibs \
   -destination "platform=iOS Simulator,name=iPhone 16" \
   COMPILER_INDEX_STORE_ENABLE=NO \
-  SWIFT_COMPILATION_MODE=wholemodule \
   CODE_SIGNING_ALLOWED=NO \
   | xcbeautify

--- a/Sources/RugbyFoundation/Core/Build/XcodeBuild/XCARGSProvider.swift
+++ b/Sources/RugbyFoundation/Core/Build/XcodeBuild/XCARGSProvider.swift
@@ -1,7 +1,6 @@
 /// The provider of xcargs which is used in Rugby.
 public final class XCARGSProvider {
-    private let base = ["COMPILER_INDEX_STORE_ENABLE=NO",
-                        "SWIFT_COMPILATION_MODE=wholemodule"]
+    private let base = ["COMPILER_INDEX_STORE_ENABLE=NO"]
     private let codeSigningNotAllowed = "CODE_SIGNING_ALLOWED=NO"
     private let disableDebugSymbolsGeneration = "GCC_GENERATE_DEBUGGING_SYMBOLS=NO"
     private let stripDebugSymbols = [

--- a/Tests/FoundationTests/Core/Build/XcodeBuild/XcodeBuildTests.swift
+++ b/Tests/FoundationTests/Core/Build/XcodeBuild/XcodeBuildTests.swift
@@ -73,7 +73,6 @@ extension XcodeBuildTests {
                 "SYMROOT=/Users/swiftyfinch/Developer/Repos/Rugby/Example/.rugby/build",
                 "-resultBundlePath build.xcresult",
                 "COMPILER_INDEX_STORE_ENABLE=NO",
-                "SWIFT_COMPILATION_MODE=wholemodule",
                 "GCC_GENERATE_DEBUGGING_SYMBOLS=NO",
                 "STRIP_INSTALLED_PRODUCT=YES",
                 "COPY_PHASE_STRIP=YES",
@@ -124,8 +123,7 @@ extension XcodeBuildTests {
                 "-parallelizeTargets",
                 "-project /Users/swiftyfinch/Developer/Repos/Rugby/Exa\\ mple/Pods/Pods.xcodeproj",
                 "SYMROOT=/Users/swiftyfinch/Developer/Repos/Rugby/Exa\\ mple/.rugby/build",
-                "COMPILER_INDEX_STORE_ENABLE=NO",
-                "SWIFT_COMPILATION_MODE=wholemodule"
+                "COMPILER_INDEX_STORE_ENABLE=NO"
             ]]
         )
     }
@@ -175,7 +173,6 @@ extension XcodeBuildTests {
                 "SYMROOT=/Users/swiftyfinch/Developer/Repos/Rugby/Example/.rugby/build",
                 "-resultBundlePath build.xcresult",
                 "COMPILER_INDEX_STORE_ENABLE=NO",
-                "SWIFT_COMPILATION_MODE=wholemodule",
                 "GCC_GENERATE_DEBUGGING_SYMBOLS=NO",
                 "STRIP_INSTALLED_PRODUCT=YES",
                 "COPY_PHASE_STRIP=YES",

--- a/Tests/FoundationTests/Core/Common/Hashers/ConfigurationsHasherTests.swift
+++ b/Tests/FoundationTests/Core/Common/Hashers/ConfigurationsHasherTests.swift
@@ -31,8 +31,7 @@ extension ConfigurationsHasherTests {
                 name: "Release",
                 buildSettings: [
                     "PRODUCT_MODULE_NAME": "KeyboardLayoutGuide",
-                    "SWIFT_OPTIMIZATION_LEVEL": "-O",
-                    "SWIFT_COMPILATION_MODE": "wholemodule"
+                    "SWIFT_OPTIMIZATION_LEVEL": "-O"
                 ]
             )
         ]
@@ -51,6 +50,6 @@ extension ConfigurationsHasherTests {
                        ["ONLY_ACTIVE_ARCH": "YES", "SWIFT_OPTIMIZATION_LEVEL": "-Onone"])
         XCTAssertEqual(hashContext[2]["name"] as? String, "Release")
         XCTAssertEqual(hashContext[2]["buildSettings"] as? [String: String],
-                       ["SWIFT_OPTIMIZATION_LEVEL": "-O", "SWIFT_COMPILATION_MODE": "wholemodule"])
+                       ["SWIFT_OPTIMIZATION_LEVEL": "-O"])
     }
 }

--- a/Tests/FoundationTests/Core/Common/Hashers/TargetsHasherTests.swift
+++ b/Tests/FoundationTests/Core/Common/Hashers/TargetsHasherTests.swift
@@ -54,7 +54,6 @@ extension TargetsHasherTests {
         buildOptions:
           xcargs:
           - COMPILER_INDEX_STORE_ENABLE=NO
-          - SWIFT_COMPILATION_MODE=wholemodule
         buildPhases:
         - Alamofire-framework_buildPhase_hash
         buildRules:
@@ -78,7 +77,6 @@ extension TargetsHasherTests {
         buildOptions:
           xcargs:
           - COMPILER_INDEX_STORE_ENABLE=NO
-          - SWIFT_COMPILATION_MODE=wholemodule
         buildPhases:
         - Moya-framework_buildPhase_hash
         buildRules:
@@ -106,7 +104,6 @@ extension TargetsHasherTests {
         buildOptions:
           xcargs:
           - COMPILER_INDEX_STORE_ENABLE=NO
-          - SWIFT_COMPILATION_MODE=wholemodule
         buildPhases:
         - LocalPod-framework-LocalPodResources_buildPhase_hash
         buildRules:
@@ -130,7 +127,6 @@ extension TargetsHasherTests {
         buildOptions:
           xcargs:
           - COMPILER_INDEX_STORE_ENABLE=NO
-          - SWIFT_COMPILATION_MODE=wholemodule
         buildPhases:
         - LocalPod-framework_buildPhase_hash
         buildRules:
@@ -188,8 +184,7 @@ extension TargetsHasherTests {
 
         // Act
         try await sut.hash(targets, xcargs: [
-            "COMPILER_INDEX_STORE_ENABLE=NO",
-            "SWIFT_COMPILATION_MODE=wholemodule"
+            "COMPILER_INDEX_STORE_ENABLE=NO"
         ])
 
         // Assert

--- a/Tests/FoundationTests/Core/Test/TestImpactManagerTests.swift
+++ b/Tests/FoundationTests/Core/Test/TestImpactManagerTests.swift
@@ -100,7 +100,7 @@ extension TestImpactManagerTests {
             sdk: .sim,
             config: "Debug",
             arch: "arm64",
-            xcargs: ["COMPILER_INDEX_STORE_ENABLE=NO", "SWIFT_COMPILATION_MODE=wholemodule"],
+            xcargs: ["COMPILER_INDEX_STORE_ENABLE=NO"],
             resultBundlePath: nil
         )
         rugbyXcodeProject.isAlreadyUsingRugbyReturnValue = false
@@ -221,7 +221,7 @@ extension TestImpactManagerTests {
             sdk: .sim,
             config: "Debug",
             arch: "arm64",
-            xcargs: ["COMPILER_INDEX_STORE_ENABLE=NO", "SWIFT_COMPILATION_MODE=wholemodule"],
+            xcargs: ["COMPILER_INDEX_STORE_ENABLE=NO"],
             resultBundlePath: nil
         )
         rugbyXcodeProject.isAlreadyUsingRugbyReturnValue = false
@@ -319,7 +319,7 @@ extension TestImpactManagerTests {
             sdk: .sim,
             config: "Debug",
             arch: "arm64",
-            xcargs: ["COMPILER_INDEX_STORE_ENABLE=NO", "SWIFT_COMPILATION_MODE=wholemodule"],
+            xcargs: ["COMPILER_INDEX_STORE_ENABLE=NO"],
             resultBundlePath: nil
         )
         rugbyXcodeProject.isAlreadyUsingRugbyReturnValue = false
@@ -398,7 +398,7 @@ extension TestImpactManagerTests {
             sdk: .sim,
             config: "Debug",
             arch: "arm64",
-            xcargs: ["COMPILER_INDEX_STORE_ENABLE=NO", "SWIFT_COMPILATION_MODE=wholemodule"],
+            xcargs: ["COMPILER_INDEX_STORE_ENABLE=NO"],
             resultBundlePath: nil
         )
         rugbyXcodeProject.isAlreadyUsingRugbyReturnValue = false

--- a/Tests/FoundationTests/Core/Test/TestsStorageTests.swift
+++ b/Tests/FoundationTests/Core/Test/TestsStorageTests.swift
@@ -50,7 +50,7 @@ extension TestsStorageTests {
             sdk: .sim,
             config: "Debug",
             arch: "arm64",
-            xcargs: ["COMPILER_INDEX_STORE_ENABLE=NO", "SWIFT_COMPILATION_MODE=wholemodule"],
+            xcargs: ["COMPILER_INDEX_STORE_ENABLE=NO"],
             resultBundlePath: nil
         )
         let localPodFrameworkUnitTests = IInternalTargetMock()
@@ -107,7 +107,7 @@ extension TestsStorageTests {
             sdk: .sim,
             config: "Debug",
             arch: "arm64",
-            xcargs: ["COMPILER_INDEX_STORE_ENABLE=NO", "SWIFT_COMPILATION_MODE=wholemodule"],
+            xcargs: ["COMPILER_INDEX_STORE_ENABLE=NO"],
             resultBundlePath: nil
         )
         let localPodFrameworkUnitTests = IInternalTargetMock()


### PR DESCRIPTION
### Description
<!--Please describe your pull request.-->
It seems that the root of the problem lies in the use of `SWIFT_COMPILATION_MODE=wholemodule` as the default setting for `xcodebuild`. While this flag was initially introduced to optimize build times, I believe that prioritizing stability is more important at this point.

### References
<!--Provide links to an existing issue or external references/discussions, if appropriate.-->
- #452 

### Checklist (I have ...)
- [x] 🧐 Followed the code style of the rest of the project
- [ ] 📖 Updated the documentation, if necessary
- [ ] 👨🏻‍🔧 Added at least one test which validates that my change is working, if appropriate
- [x] 👮🏻‍♂️ Run `make lint` and fixed all warnings
- [x] ✅ Run `make test` and fixed all tests

❤️ Thanks for contributing to the 🏈 Rugby!
