### PR TITLE
🤖 Exclude PLzmaSDK from Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      # Product 'PLzmaSDK' contains unsafe build flags.
+      - dependency-name: "github.com/OlehKulykov/PLzmaSDK"


### PR DESCRIPTION
### Description
<!--Please describe your pull request.-->
This pull request updates the `.github/dependabot.yml` configuration to exclude the PLzmaSDK dependency from regular updates by Dependabot. The change ensures that Dependabot does not attempt to update this dependency, avoiding potential issues caused by unsafe flags or compatibility concerns.

```sh
error: 'repo': the target 'libplzma' in product 'PLzmaSDK' contains unsafe build flags
```

### References
<!--Provide links to an existing issue or external references/discussions, if appropriate.-->
- https://github.com/OlehKulykov/PLzmaSDK/blob/master/Package.swift#L21

### Checklist (I have ...)
- [ ] 🧐 Followed the code style of the rest of the project
- [ ] 📖 Updated the documentation, if necessary
- [ ] 👨🏻‍🔧 Added at least one test which validates that my change is working, if appropriate
- [x] 👮🏻‍♂️ Run `make lint` and fixed all warnings
- [x] ✅ Run `make test` and fixed all tests

❤️ Thanks for contributing to the 🏈 Rugby!
